### PR TITLE
fix docz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
                 at: ~/
             - run:
                 name: Build
-                command: yarn test
+                command: yarn workspace button run rollup && yarn docz:build
             - slack/status:
                 fail_only: true
                 failure_message: ':alert: A $CIRCLE_JOB job has failed build!'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,21 +75,6 @@ jobs:
                 fail_only: true
                 failure_message: ':alert: A $CIRCLE_JOB job has failed build!'
                 mentions: 'bje'
-  deploy-docs:
-    executor:
-      name: node/default
-    steps:
-      - node/with-cache:
-          steps:
-            - attach_workspace:
-                at: ~/
-            - run:
-                name: Build
-                command: yarn test
-            - slack/status:
-                fail_only: true
-                failure_message: ':alert: A $CIRCLE_JOB job has failed deployment!'
-                mentions: 'bje'
 workflows:
   build-and-test:
     jobs:
@@ -104,9 +89,3 @@ workflows:
           requires:
             - lint
             - test
-      - deploy-docs:
-          requires:
-            - build
-          filters:
-            branches:
-              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,80 +1,78 @@
 version: 2.1
+
 orbs:
-  node: circleci/node@1.1.6
+  node: circleci/node@3.0.1
   slack: circleci/slack@3.4.2
+
 jobs:
   install:
     executor:
       name: node/default
+      tag: '12.16.3'
     steps:
       - checkout
-      - node/with-cache:
-          steps:
-            - restore_cache:
-                name: Restore Yarn Package Cache
-                keys:
-                  - yarn-packages-{{ checksum "yarn.lock" }}
-            - run:
-                name: Install Dependencies
-                command: yarn install
-            - save_cache:
-                name: Save Yarn Package Cache
-                key: yarn-packages-{{ checksum "yarn.lock" }}
-                paths:
-                  - ~/.cache/yarn
-            - persist_to_workspace:
-                root: ~/
-                paths:
-                  - '*'
-            - slack/status:
-                fail_only: true
-                failure_message: ':alert: A $CIRCLE_JOB job has failed installation!'
-                mentions: 'bje'
+      - node/install-packages:
+          pkg-manager: yarn
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - '*'
+      - slack/status:
+          fail_only: true
+          failure_message: ':alert: $CIRCLE_JOB has failed install!'
+          mentions: 'bje'
+
   lint:
     executor:
       name: node/default
+      tag: '12.16.3'
     steps:
-      - node/with-cache:
-          steps:
-            - attach_workspace:
-                at: ~/
-            - run:
-                name: Eslint
-                command: yarn lint
-            - slack/status:
-                fail_only: true
-                failure_message: ':alert: A $CIRCLE_JOB job has failed linting!'
-                mentions: 'bje'
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Eslint
+          command: yarn lint
+      - slack/status:
+          fail_only: true
+          failure_message: ':alert: $CIRCLE_JOB has failed lint!'
+          mentions: 'bje'
+
   test:
     executor:
       name: node/default
+      tag: '12.16.3'
     steps:
-      - node/with-cache:
-          steps:
-            - attach_workspace:
-                at: ~/
-            - run:
-                name: Unit Tests
-                command: yarn test
-            - slack/status:
-                fail_only: true
-                failure_message: ':alert: A $CIRCLE_JOB job has unit tests!'
-                mentions: 'bje'
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command: yarn test --ci --runInBand --reporters=default --reporters=jest-junit
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./coverage/junit/
+      - store_test_results:
+          path: ./coverage/junit/
+      - store_artifacts:
+          path: ./coverage
+      - slack/status:
+          fail_only: true
+          failure_message: ':alert: $CIRCLE_JOB has failed test!'
+          mentions: 'bje'
+
   build:
     executor:
       name: node/default
+      tag: '12.16.3'
     steps:
-      - node/with-cache:
-          steps:
-            - attach_workspace:
-                at: ~/
-            - run:
-                name: Build
-                command: yarn workspace button run rollup && yarn docz:build
-            - slack/status:
-                fail_only: true
-                failure_message: ':alert: A $CIRCLE_JOB job has failed build!'
-                mentions: 'bje'
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Build
+          command: yarn workspace button run rollup && yarn docz:build
+      - slack/status:
+          fail_only: true
+          failure_message: ':alert: $CIRCLE_JOB has failed build!'
+          mentions: 'bje'
+
 workflows:
   build-and-test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   install:
     executor:
       name: node/default
-      tag: '12.16.3'
+      tag: '14.5.0'
     steps:
       - checkout
       - node/install-packages:
@@ -25,7 +25,7 @@ jobs:
   lint:
     executor:
       name: node/default
-      tag: '12.16.3'
+      tag: '14.5.0'
     steps:
       - attach_workspace:
           at: ~/
@@ -40,7 +40,7 @@ jobs:
   test:
     executor:
       name: node/default
-      tag: '12.16.3'
+      tag: '14.5.0'
     steps:
       - attach_workspace:
           at: ~/
@@ -61,7 +61,7 @@ jobs:
   build:
     executor:
       name: node/default
-      tag: '12.16.3'
+      tag: '14.5.0'
     steps:
       - attach_workspace:
           at: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,9 @@ jobs:
           mentions: 'bje'
 
   lint:
-    executor: node/default
+    executor:
+      name: node/default
+      tag: '14.5.0'
     steps:
       - attach_workspace:
           at: ~/
@@ -36,7 +38,9 @@ jobs:
           mentions: 'bje'
 
   test:
-    executor: node/default
+    executor:
+      name: node/default
+      tag: '14.5.0'
     steps:
       - attach_workspace:
           at: ~/
@@ -55,7 +59,9 @@ jobs:
           mentions: 'bje'
 
   build:
-    executor: node/default
+    executor:
+      name: node/default
+      tag: '14.5.0'
     steps:
       - attach_workspace:
           at: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           mentions: 'bje'
 
   lint:
+    executor: node/default
     steps:
       - attach_workspace:
           at: ~/
@@ -35,6 +36,7 @@ jobs:
           mentions: 'bje'
 
   test:
+    executor: node/default
     steps:
       - attach_workspace:
           at: ~/
@@ -53,6 +55,7 @@ jobs:
           mentions: 'bje'
 
   build:
+    executor: node/default
     steps:
       - attach_workspace:
           at: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,6 @@ jobs:
           mentions: 'bje'
 
   lint:
-    executor:
-      name: node/default
-      tag: '14.5.0'
     steps:
       - attach_workspace:
           at: ~/
@@ -38,9 +35,6 @@ jobs:
           mentions: 'bje'
 
   test:
-    executor:
-      name: node/default
-      tag: '14.5.0'
     steps:
       - attach_workspace:
           at: ~/
@@ -59,9 +53,6 @@ jobs:
           mentions: 'bje'
 
   build:
-    executor:
-      name: node/default
-      tag: '14.5.0'
     steps:
       - attach_workspace:
           at: ~/

--- a/.circleci/config_bu.yml
+++ b/.circleci/config_bu.yml
@@ -1,0 +1,91 @@
+version: 2.1
+orbs:
+  node: circleci/node@1.1.6
+  slack: circleci/slack@3.4.2
+jobs:
+  install:
+    executor:
+      name: node/default
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - restore_cache:
+                name: Restore Yarn Package Cache
+                keys:
+                  - yarn-packages-{{ checksum "yarn.lock" }}
+            - run:
+                name: Install Dependencies
+                command: yarn install
+            - save_cache:
+                name: Save Yarn Package Cache
+                key: yarn-packages-{{ checksum "yarn.lock" }}
+                paths:
+                  - ~/.cache/yarn
+            - persist_to_workspace:
+                root: ~/
+                paths:
+                  - '*'
+            - slack/status:
+                fail_only: true
+                failure_message: ':alert: A $CIRCLE_JOB job has failed installation!'
+                mentions: 'bje'
+  lint:
+    executor:
+      name: node/default
+    steps:
+      - node/with-cache:
+          steps:
+            - attach_workspace:
+                at: ~/
+            - run:
+                name: Eslint
+                command: yarn lint
+            - slack/status:
+                fail_only: true
+                failure_message: ':alert: A $CIRCLE_JOB job has failed linting!'
+                mentions: 'bje'
+  test:
+    executor:
+      name: node/default
+    steps:
+      - node/with-cache:
+          steps:
+            - attach_workspace:
+                at: ~/
+            - run:
+                name: Unit Tests
+                command: yarn test
+            - slack/status:
+                fail_only: true
+                failure_message: ':alert: A $CIRCLE_JOB job has unit tests!'
+                mentions: 'bje'
+  build:
+    executor:
+      name: node/default
+    steps:
+      - node/with-cache:
+          steps:
+            - attach_workspace:
+                at: ~/
+            - run:
+                name: Build
+                command: yarn workspace button run rollup && yarn docz:build
+            - slack/status:
+                fail_only: true
+                failure_message: ':alert: A $CIRCLE_JOB job has failed build!'
+                mentions: 'bje'
+workflows:
+  build-and-test:
+    jobs:
+      - install
+      - lint:
+          requires:
+            - install
+      - test:
+          requires:
+            - install
+      - build:
+          requires:
+            - lint
+            - test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .env
 coverage
+build
 dist
 es
 lerna-debug.log

--- a/design/ui/button/README.mdx
+++ b/design/ui/button/README.mdx
@@ -7,6 +7,8 @@ import { Button } from './es';
 
 # Button
 
+We definitely want to consume the compiled version of the components in these docs since that is what our developers will be consuming.
+
 It feels like there is a lot of boilerplate for these MDX documents that we could definitely abstract out. Next steps will be to also make some display components to use in MDX like do/don't lists, etc. Page should probably automatically give the "name" without having to add it.
 
 Will probably modify the Docz Props and Playground components to do a little more what we want.

--- a/design/ui/button/README.mdx
+++ b/design/ui/button/README.mdx
@@ -2,9 +2,8 @@
 name: Button
 ---
 
-import 'semantic-ui-css-offline';
 import { Playground, Props } from 'docz';
-import { EspButton } from './es';
+import { Button } from './es';
 
 # Button
 
@@ -17,12 +16,12 @@ Still to also explore here:
 - [ ] Generate the playgrounds from fixture files
 - [ ] List any atomic components that the component might be built out of (if any)
 
-<Props of={EspButton} />
+<Props of={Button} />
 
 <Playground>
-  <EspButton content='Docz Demo' />
+  <Button content='Docz Demo' />
 </Playground>
 
 <Playground>
-  <EspButton content='Positive' outcome='positive' />
+  <Button content='Positive' outcome='positive' />
 </Playground>

--- a/design/ui/button/package.json
+++ b/design/ui/button/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@espressive/button",
+  "name": "button",
   "version": "1.0.0",
   "main": "dist/index.js",
   "module": "es/index.js",
@@ -33,7 +33,7 @@
     "rollup-plugin-postcss": "3.1.3"
   },
   "scripts": {
-    "rollup": "rm -rf dist && rm -rf es && BABEL_ENV=production rollup -c",
-    "rollup:watch": "rm -rf dist && rm -rf es && BABEL_ENV=production rollup -c --watch"
+    "rollup": "rm -rf dist && rm -rf es && BABEL_ENV=development rollup -c",
+    "rollup:watch": "rm -rf dist && rm -rf es && BABEL_ENV=development rollup -c --watch"
   }
 }

--- a/design/ui/button/package.json
+++ b/design/ui/button/package.json
@@ -1,7 +1,6 @@
 {
   "name": "button",
   "version": "1.0.0",
-  "main": "dist/index.js",
   "module": "es/index.js",
   "dependencies": {
     "babel-preset-espressive": "*",

--- a/design/ui/button/rollup.config.js
+++ b/design/ui/button/rollup.config.js
@@ -14,6 +14,17 @@ export default {
       format: 'es',
     },
   ],
+  // These are any exernal modules that we do not want to include in our builds. If we include
+  // a module in this list, it should also be declared as a peer depenency for our package. In
+  // the future we need to have a way to easily check these definitions for our overall library.
+  // This might be another reason that it is good to move this configuration to the root level
+  // for overall consistency.
+  external: ['react', 'prop-types', 'classnames/bind'],
+  // Adding this onwarn config to throw an error and fail if we have any warnings so we do not
+  // have anything unresolved we do not see.
+  // onwarn: (warning) => {
+  //   throw new Error(warning.message);
+  // },
   plugins: [
     postcss({
       // extract: 'styles.css',

--- a/design/ui/semantic-ui-css-custom/README.mdx
+++ b/design/ui/semantic-ui-css-custom/README.mdx
@@ -1,0 +1,1 @@
+# semantic-ui-css-custom

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,6 @@
 export default {
-  title: 'Espressive FDS',
-  dest: '/docs',
+  title: 'Cascara',
+  dest: '/build/docs',
   // menu: ['Introduction', 'Variables', 'UI', 'Layouts'],
   port: 4000,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -150,9 +150,7 @@ module.exports = {
   testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: ['.docz', '/node_modules/'],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "husky": "4.2.5",
     "identity-obj-proxy": "3.0.0",
     "jest": "26.1.0",
+    "jest-junit": "11.1.0",
     "lint-staged": "10.2.11",
     "prettier": "2.0.5",
     "react-test-renderer": "16.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10573,6 +10573,16 @@ jest-jasmine2@^26.1.0:
     pretty-format "^26.1.0"
     throat "^5.0.0"
 
+jest-junit@11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-11.1.0.tgz#79cd53948e44d62b2b30fa23ea0d7a899d2c8d7a"
+  integrity sha512-c2LFOyKY7+ZxL5zSu+WHmHfsJ2wqbOpeYJ4Uu26yMhFxny2J2NQj6AVS7M+Eaxji9Q/oIDDK5tQy0DGzDp9xOw==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^5.2.0"
+    uuid "^3.3.3"
+    xml "^1.0.1"
+
 jest-leak-detector@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
@@ -18329,7 +18339,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@3.4.0, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
+uuid@3.4.0, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -19155,6 +19165,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlchars@^2.1.1, xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Removing checklist since this does not impact components.

This fixes Rollbar output so it no longer compiles runtimes that have prop-types stripped. In the long run... trying to use a config that works the same as react-scripts for the runtimes in Rollbar might not actually be the best path forward since our needs are different as a package library. We might need to have our own config that we maintain ourselves for building runtimes of components. This will mean we also needs some tests on making sure these components also work in other environments on their own. Lots of testing work to be done on the runtimes themselves separate from the unit testing.

Once this PR gets merged and we make another merge to main from develop... I think this will also deploy correctly on Netlify.