### PR TITLE
Strict mode works for fixtures

### DIFF
--- a/src/layout/admin/src/Admin.js
+++ b/src/layout/admin/src/Admin.js
@@ -13,7 +13,7 @@ const Admin = ({ children }) => {
   useSetLayoutAttribute('admin');
 
   // We only want to return the children in the root node and set styles on the #root
-  return children;
+  return children || null;
 };
 
 Admin.propTypes = propTypes;

--- a/src/layout/admin/src/cosmos.decorator.js
+++ b/src/layout/admin/src/cosmos.decorator.js
@@ -1,0 +1,11 @@
+// NOTE: This decorator is inherited by all fixtures in this directory.
+//
+// Decorators are inherited from parent folders. Please check that there
+// is not another decorator higher up in the directory tree that is not already
+// adding something we need. If a fixture has unique needs, a decorater can be
+// created in child directories to extend this further.
+
+import React, { StrictMode } from 'react';
+
+// export is needed or else this decorator mutes all fixture children
+export default ({ children }) => <StrictMode>{children}</StrictMode>;

--- a/src/layout/admin/src/index.js
+++ b/src/layout/admin/src/index.js
@@ -1,1 +1,1 @@
-export default from './Admin';
+export { default } from './Admin';

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -3,3 +3,5 @@
 All of our components here should initially be our UI elements that the design system is built from. The API surface area of all components should be as simple as possible to make use easier, but also to make sure we are keeping consistency in our UI.
 
 In the long run, this area might need to be organized into different areas if the system grows so we can take care of all of our needs.
+
+import { Button } from 'cascara'

--- a/src/ui/button/src/Button.fixture.js
+++ b/src/ui/button/src/Button.fixture.js
@@ -28,7 +28,12 @@ export default {
     />
   ),
   default: <Button content='Default' />,
-  fluid: <Button content='Fluid' fluid />,
+  fluid: (
+    <div>
+      <Button content='Fluid' fluid />
+      <button className='ui primary fluid button'>Hello</button>
+    </div>
+  ),
   positive: <Button content='Positive' outcome='positive' />,
   negative: <Button content='Negative' outcome='negative' />,
   link: (

--- a/src/ui/button/src/cosmos.decorator.js
+++ b/src/ui/button/src/cosmos.decorator.js
@@ -1,0 +1,11 @@
+// NOTE: This decorator is inherited by all fixtures in this directory.
+//
+// Decorators are inherited from parent folders. Please check that there
+// is not another decorator higher up in the directory tree that is not already
+// adding something we need. If a fixture has unique needs, a decorater can be
+// created in child directories to extend this further.
+
+import React, { StrictMode } from 'react';
+
+// export is needed or else this decorator mutes all fixture children
+export default ({ children }) => <StrictMode>{children}</StrictMode>;

--- a/src/ui/pagination/src/cosmos.decorator.js
+++ b/src/ui/pagination/src/cosmos.decorator.js
@@ -1,0 +1,11 @@
+// NOTE: This decorator is inherited by all fixtures in this directory.
+//
+// Decorators are inherited from parent folders. Please check that there
+// is not another decorator higher up in the directory tree that is not already
+// adding something we need. If a fixture has unique needs, a decorater can be
+// created in child directories to extend this further.
+
+import React, { StrictMode } from 'react';
+
+// export is needed or else this decorator mutes all fixture children
+export default ({ children }) => <StrictMode>{children}</StrictMode>;


### PR DESCRIPTION
Cannot set this at the root due to JSX. This is also because of our webpack config relying on CRA.

We will need to add this in the /src folder for each component for now. We still inherit the other fixture globals.
