### PR TITLE
resolves #77 add docs to CI, adjust build phases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - slack/status:
           fail_only: true
           include_project_field: false
-          # mentions: 'here'
+          mentions: 'bje'
 
   lint:
     executor:
@@ -35,7 +35,7 @@ jobs:
       - slack/status:
           fail_only: true
           include_project_field: false
-          # mentions: 'here'
+          mentions: 'bje'
 
   test:
     executor:
@@ -56,7 +56,7 @@ jobs:
       - slack/status:
           fail_only: true
           include_project_field: false
-          # mentions: 'here'
+          mentions: 'bje'
 
   build-cosmos:
     executor:
@@ -71,7 +71,7 @@ jobs:
       - slack/status:
           fail_only: true
           include_project_field: false
-          # mentions: 'here'
+          mentions: 'bje'
 
   build-docs:
     executor:
@@ -86,7 +86,7 @@ jobs:
       - slack/status:
           fail_only: true
           include_project_field: false
-          # mentions: 'here'
+          mentions: 'bje'
 
   build-cascara:
     executor:
@@ -101,7 +101,7 @@ jobs:
       - slack/status:
           fail_only: true
           include_project_field: false
-          # mentions: 'here'
+          mentions: 'bje'
 
 workflows:
   build-and-test:
@@ -113,6 +113,9 @@ workflows:
       - test:
           requires:
             - install
+      - build-cascara:
+          requires:
+            - install
       - build-cosmos:
           requires:
             - lint
@@ -121,7 +124,4 @@ workflows:
           requires:
             - lint
             - test
-      - build-cascara:
-          requires:
-            - lint
-            - test
+            - build-cascara

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - save_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
           paths:
             - ~/
       - slack/status:
@@ -28,7 +28,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
       - run:
           name: Run Eslint
           command: yarn lint --format junit --output-file ./coverage/eslint.xml
@@ -47,7 +47,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
       - run:
           name: Run Unit Tests
           command: yarn test --ci --runInBand --reporters=default --reporters=jest-junit
@@ -68,7 +68,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
       - run:
           name: Build Cascara Runtimes
           command: make
@@ -90,7 +90,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
       - run:
           name: Build Cosmos
           command: yarn cosmos:build
@@ -107,7 +107,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
       - restore_cache:
           key: cascara-CASCARA_RUNTIMES-{{ .Revision }}-{{ checksum "yarn.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           paths:
             - /home/circleci/project/packages/cascara/dist
       - store_artifacts:
-          path: /home/circleci/project/packages/cascara/dist
+          path: ./packages/cascara/dist
           destination: dist
       - slack/status:
           fail_only: true
@@ -95,7 +95,8 @@ jobs:
           name: Build Cosmos
           command: yarn cosmos:build
       - store_artifacts:
-          path: ./build
+          path: ./build/cosmos
+          destination: cosmos
       - slack/status:
           fail_only: true
           include_project_field: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - '*'
+      # - persist_to_workspace:
+      #     root: ~/
+      #     paths:
+      #       - '*'
       - slack/status:
           fail_only: true
           include_project_field: false
@@ -63,8 +63,8 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - attach_workspace:
-          at: ~/
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Build Cascara Runtimes
           command: make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
+      - checkout
       - node/install-packages:
           pkg-manager: yarn
       - run:
@@ -42,6 +43,7 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
+      - checkout
       - node/install-packages:
           pkg-manager: yarn
       - run:
@@ -63,6 +65,7 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
+      - checkout
       - node/install-packages:
           pkg-manager: yarn
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,10 +69,10 @@ jobs:
           name: Build Cascara Runtimes
           command: make
       - persist_to_workspace:
-          root: ~/
+          root: /packages/cascara
           paths:
-            - 'packages/cascara/cjs'
-            - 'packages/cascara/es'
+            - cjs
+            - es
       - slack/status:
           fail_only: true
           include_project_field: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,26 @@ jobs:
           include_project_field: false
           mentions: 'bje'
 
+  build-cascara:
+    executor:
+      name: node/default
+      tag: '14.5.0'
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Build Cascara Runtimes
+          command: make
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - 'packages/cascara/cjs'
+            - 'packages/cascara/es'
+      - slack/status:
+          fail_only: true
+          include_project_field: false
+          mentions: 'bje'
+
   build-cosmos:
     executor:
       name: node/default
@@ -88,21 +108,6 @@ jobs:
           include_project_field: false
           mentions: 'bje'
 
-  build-cascara:
-    executor:
-      name: node/default
-      tag: '14.5.0'
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Build Cascara Runtimes
-          command: make
-      - slack/status:
-          fail_only: true
-          include_project_field: false
-          mentions: 'bje'
-
 workflows:
   build-and-test:
     jobs:
@@ -122,6 +127,6 @@ workflows:
             - test
       - build-docs:
           requires:
+            - build-cascara
             - lint
             - test
-            - build-cascara

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           include_project_field: false
           mentions: 'here'
 
-  cosmos:
+  build-cosmos:
     executor:
       name: node/default
       tag: '14.5.0'
@@ -73,7 +73,22 @@ jobs:
           include_project_field: false
           mentions: 'here'
 
-  build:
+  build-docs:
+    executor:
+      name: node/default
+      tag: '14.5.0'
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Build
+          command: yarn docs build
+      - slack/status:
+          fail_only: true
+          include_project_field: false
+          mentions: 'here'
+
+  build-cascara:
     executor:
       name: node/default
       tag: '14.5.0'
@@ -98,9 +113,18 @@ workflows:
       - test:
           requires:
             - install
-      - cosmos:
+      - build-cosmos:
           requires:
             - install
-      - build:
+            - lint
+            - test
+      - build-docs:
           requires:
             - install
+            - lint
+            - test
+      - build-cascara:
+          requires:
+            - install
+            - lint
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,11 @@ jobs:
       - run:
           name: Build Cascara Runtimes
           command: make
-      - persist_to_workspace:
-          root: /home/circleci/project/packages/cascara
+      - save_cache:
+          key: cascara-{{ .Revision }}-{{ checksum "yarn.lock" }}
           paths:
-            - cjs
-            - es
+            - /home/circleci/project/packages/cascara/cjs
+            - /home/circleci/project/packages/cascara/es
       - slack/status:
           fail_only: true
           include_project_field: false
@@ -86,8 +86,9 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Build Cosmos
           command: yarn cosmos:build
@@ -101,8 +102,14 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+      - restore_cache:
+          key: cascara-{{ .Revision }}-{{ checksum "yarn.lock" }}
+          paths:
+            - /home/circleci/project/packages/cascara/cjs
+            - /home/circleci/project/packages/cascara/es
       - run:
           name: Build Docs
           command: yarn docs build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: node_modules--CASCARA--{{ checksum "yarn.lock" }}
+          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
           with-cache: false
       - save_cache:
-          key: node_modules-cascara-{{ checksum "yarn.lock" }}
+          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
           paths:
             - /home/circleci/project/node_modules
             # - /home/circleci/project/packages/*/node_modules
@@ -40,7 +40,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: node_modules-cascara-{{ checksum "yarn.lock" }}
+          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
           with-cache: false
@@ -63,7 +63,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: node_modules-cascara-{{ checksum "yarn.lock" }}
+          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
           with-cache: false
@@ -88,7 +88,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: node_modules-cascara-{{ checksum "yarn.lock" }}
+          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
           with-cache: false
@@ -114,7 +114,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: node_modules-cascara-{{ checksum "yarn.lock" }}
+          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
           with-cache: false
@@ -135,7 +135,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: node_modules-cascara-{{ checksum "yarn.lock" }}
+          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
           with-cache: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - slack/status:
           fail_only: true
           include_project_field: false
-          mentions: 'here'
+          # mentions: 'here'
 
   lint:
     executor:
@@ -30,12 +30,12 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Eslint
+          name: Run Eslint
           command: yarn lint
       - slack/status:
           fail_only: true
           include_project_field: false
-          mentions: 'here'
+          # mentions: 'here'
 
   test:
     executor:
@@ -45,7 +45,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Run tests
+          name: Run Unit Tests
           command: yarn test --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./coverage/junit/
@@ -56,7 +56,7 @@ jobs:
       - slack/status:
           fail_only: true
           include_project_field: false
-          mentions: 'here'
+          # mentions: 'here'
 
   build-cosmos:
     executor:
@@ -66,12 +66,12 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Build
+          name: Build Cosmos
           command: yarn cosmos:build
       - slack/status:
           fail_only: true
           include_project_field: false
-          mentions: 'here'
+          # mentions: 'here'
 
   build-docs:
     executor:
@@ -81,12 +81,12 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Build
+          name: Build Docs
           command: yarn docs build
       - slack/status:
           fail_only: true
           include_project_field: false
-          mentions: 'here'
+          # mentions: 'here'
 
   build-cascara:
     executor:
@@ -96,12 +96,12 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Build
+          name: Build Cascara Runtimes
           command: make
       - slack/status:
           fail_only: true
           include_project_field: false
-          mentions: 'here'
+          # mentions: 'here'
 
 workflows:
   build-and-test:
@@ -115,16 +115,13 @@ workflows:
             - install
       - build-cosmos:
           requires:
-            - install
             - lint
             - test
       - build-docs:
           requires:
-            - install
             - lint
             - test
       - build-cascara:
           requires:
-            - install
             - lint
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
+          key: node_modules--CASCARA--{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
           with-cache: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           name: Build Cascara Runtimes
           command: make
       - persist_to_workspace:
-          root: /packages/cascara
+          root: /home/circleci/project/packages/cascara
           paths:
             - cjs
             - es

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - attach_workspace:
-          at: ~/
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Run Eslint
           command: yarn lint
@@ -42,8 +42,8 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - attach_workspace:
-          at: ~/
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Run Unit Tests
           command: yarn test --ci --runInBand --reporters=default --reporters=jest-junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,6 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
-      # - persist_to_workspace:
-      #     root: ~/
-      #     paths:
-      #       - '*'
       - slack/status:
           fail_only: true
           include_project_field: false
@@ -74,8 +70,10 @@ jobs:
       - save_cache:
           key: cascara-{{ .Revision }}-{{ checksum "yarn.lock" }}
           paths:
-            - /home/circleci/project/packages/cascara/cjs
-            - /home/circleci/project/packages/cascara/es
+            - /home/circleci/project/packages/cascara/dist
+      - store_artifacts:
+          path: /home/circleci/project/packages/cascara/dist
+          destination: dist
       - slack/status:
           fail_only: true
           include_project_field: false
@@ -92,6 +90,8 @@ jobs:
       - run:
           name: Build Cosmos
           command: yarn cosmos:build
+      - store_artifacts:
+          path: ./build
       - slack/status:
           fail_only: true
           include_project_field: false
@@ -108,8 +108,7 @@ jobs:
       - restore_cache:
           key: cascara-{{ .Revision }}-{{ checksum "yarn.lock" }}
           paths:
-            - /home/circleci/project/packages/cascara/cjs
-            - /home/circleci/project/packages/cascara/es
+            - /home/circleci/project/packages/cascara/dist
       - run:
           name: Build Docs
           command: yarn docs build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,23 @@ jobs:
       tag: '14.5.0'
     steps:
       - checkout
+      - restore_cache:
+          key: node_modules-cascara-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
-      - slack/status:
+          with-cache: false
+      - save_cache:
+          key: node_modules-cascara-{{ checksum "yarn.lock" }}
+          paths:
+            - /home/circleci/project/node_modules
+            - /home/circleci/project/packages/*/node_modules
+            # - /home/circleci/project/packages/cascara/node_modules
+            # - /home/circleci/project/packages/framer/node_modules
+            # - /home/circleci/project/packages/tokens/node_modules
+            - /home/circleci/project/utils/*/node_modules
+            # - /home/circleci/project/utils/babel-preset-espressive/node_modules
+            # - /home/circleci/project/utils/eslint-config-espressive/node_modules
+            # - /home/circleci/project/utils/legacy-css/node_modules      - slack/status:
           fail_only: true
           include_project_field: false
           mentions: 'bje'
@@ -24,8 +38,11 @@ jobs:
       tag: '14.5.0'
     steps:
       - checkout
+      - restore_cache:
+          key: node_modules-cascara-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
+          with-cache: false
       - run:
           name: Run Eslint
           command: yarn lint --format junit --output-file ./coverage/eslint.xml
@@ -44,8 +61,11 @@ jobs:
       tag: '14.5.0'
     steps:
       - checkout
+      - restore_cache:
+          key: node_modules-cascara-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
+          with-cache: false
       - run:
           name: Run Unit Tests
           command: yarn test --ci --runInBand --reporters=default --reporters=jest-junit
@@ -66,8 +86,11 @@ jobs:
       tag: '14.5.0'
     steps:
       - checkout
+      - restore_cache:
+          key: node_modules-cascara-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
+          with-cache: false
       - run:
           name: Build Cascara Runtimes
           command: make
@@ -89,8 +112,11 @@ jobs:
       tag: '14.5.0'
     steps:
       - checkout
+      - restore_cache:
+          key: node_modules-cascara-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
+          with-cache: false
       - run:
           name: Build Cosmos
           command: yarn cosmos:build
@@ -107,8 +133,11 @@ jobs:
       tag: '14.5.0'
     steps:
       - checkout
+      - restore_cache:
+          key: node_modules-cascara-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
+          with-cache: false
       - restore_cache:
           key: cascara-{{ .Revision }}-{{ checksum "yarn.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
             # - /home/circleci/project/utils/*/node_modules
             - /home/circleci/project/utils/babel-preset-espressive/node_modules
             - /home/circleci/project/utils/eslint-config-espressive/node_modules
-            - /home/circleci/project/utils/legacy-css/node_modules      
-        - slack/status:
+            - /home/circleci/project/utils/legacy-css/node_modules
+      - slack/status:
           fail_only: true
           include_project_field: false
           mentions: 'bje'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - save_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
           paths:
             - ~/
       - slack/status:
@@ -28,7 +28,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
       - run:
           name: Run Eslint
           command: yarn lint --format junit --output-file ./coverage/eslint.xml
@@ -47,7 +47,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
       - run:
           name: Run Unit Tests
           command: yarn test --ci --runInBand --reporters=default --reporters=jest-junit
@@ -68,7 +68,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
       - run:
           name: Build Cascara Runtimes
           command: make
@@ -90,7 +90,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
       - run:
           name: Build Cosmos
           command: yarn cosmos:build
@@ -107,7 +107,7 @@ jobs:
       tag: '14.5.0'
     steps:
       - restore_cache:
-          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ .BuildNum }}
       - restore_cache:
           key: cascara-CASCARA_RUNTIMES-{{ .Revision }}-{{ checksum "yarn.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,11 @@ jobs:
           pkg-manager: yarn
       - run:
           name: Run Eslint
-          command: yarn lint
+          command: yarn lint --format junit --output-file ./coverage/eslint.xml
+      - store_test_results:
+          path: ./coverage
+      - store_artifacts:
+          path: ./coverage
       - slack/status:
           fail_only: true
           include_project_field: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,23 +11,12 @@ jobs:
       tag: '14.5.0'
     steps:
       - checkout
-      - restore_cache:
-          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
-          with-cache: false
       - save_cache:
-          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
           paths:
-            - /home/circleci/project/node_modules
-            # - /home/circleci/project/packages/*/node_modules
-            - /home/circleci/project/packages/cascara/node_modules
-            - /home/circleci/project/packages/framer/node_modules
-            - /home/circleci/project/packages/tokens/node_modules
-            # - /home/circleci/project/utils/*/node_modules
-            - /home/circleci/project/utils/babel-preset-espressive/node_modules
-            - /home/circleci/project/utils/eslint-config-espressive/node_modules
-            - /home/circleci/project/utils/legacy-css/node_modules
+            - ~/
       - slack/status:
           fail_only: true
           include_project_field: false
@@ -38,12 +27,8 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - checkout
       - restore_cache:
-          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
-      - node/install-packages:
-          pkg-manager: yarn
-          with-cache: false
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
       - run:
           name: Run Eslint
           command: yarn lint --format junit --output-file ./coverage/eslint.xml
@@ -61,12 +46,8 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - checkout
       - restore_cache:
-          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
-      - node/install-packages:
-          pkg-manager: yarn
-          with-cache: false
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
       - run:
           name: Run Unit Tests
           command: yarn test --ci --runInBand --reporters=default --reporters=jest-junit
@@ -86,17 +67,13 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - checkout
       - restore_cache:
-          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
-      - node/install-packages:
-          pkg-manager: yarn
-          with-cache: false
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
       - run:
           name: Build Cascara Runtimes
           command: make
       - save_cache:
-          key: cascara-{{ .Revision }}-{{ checksum "yarn.lock" }}
+          key: cascara-CASCARA_RUNTIMES-{{ .Revision }}-{{ checksum "yarn.lock" }}
           paths:
             - /home/circleci/project/packages/cascara/dist
       - store_artifacts:
@@ -112,12 +89,8 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - checkout
       - restore_cache:
-          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
-      - node/install-packages:
-          pkg-manager: yarn
-          with-cache: false
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
       - run:
           name: Build Cosmos
           command: yarn cosmos:build
@@ -133,16 +106,10 @@ jobs:
       name: node/default
       tag: '14.5.0'
     steps:
-      - checkout
       - restore_cache:
-          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
-      - node/install-packages:
-          pkg-manager: yarn
-          with-cache: false
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}-{{ checksum "yarn.lock" }}
       - restore_cache:
-          key: cascara-{{ .Revision }}-{{ checksum "yarn.lock" }}
-          paths:
-            - /home/circleci/project/packages/cascara/dist
+          key: cascara-CASCARA_RUNTIMES-{{ .Revision }}-{{ checksum "yarn.lock" }}
       - run:
           name: Build Docs
           command: yarn docs build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: node_modules-cascara-{{ checksum "yarn.lock" }}
+          key: node_modules-CASCARA-{{ checksum "yarn.lock" }}
       - node/install-packages:
           pkg-manager: yarn
           with-cache: false
@@ -20,14 +20,15 @@ jobs:
           key: node_modules-cascara-{{ checksum "yarn.lock" }}
           paths:
             - /home/circleci/project/node_modules
-            - /home/circleci/project/packages/*/node_modules
-            # - /home/circleci/project/packages/cascara/node_modules
-            # - /home/circleci/project/packages/framer/node_modules
-            # - /home/circleci/project/packages/tokens/node_modules
-            - /home/circleci/project/utils/*/node_modules
-            # - /home/circleci/project/utils/babel-preset-espressive/node_modules
-            # - /home/circleci/project/utils/eslint-config-espressive/node_modules
-            # - /home/circleci/project/utils/legacy-css/node_modules      - slack/status:
+            # - /home/circleci/project/packages/*/node_modules
+            - /home/circleci/project/packages/cascara/node_modules
+            - /home/circleci/project/packages/framer/node_modules
+            - /home/circleci/project/packages/tokens/node_modules
+            # - /home/circleci/project/utils/*/node_modules
+            - /home/circleci/project/utils/babel-preset-espressive/node_modules
+            - /home/circleci/project/utils/eslint-config-espressive/node_modules
+            - /home/circleci/project/utils/legacy-css/node_modules      
+        - slack/status:
           fail_only: true
           include_project_field: false
           mentions: 'bje'

--- a/packages/cascara/package.json
+++ b/packages/cascara/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@espressive/cascara",
   "version": "0.1.1-alpha.10",
-  "main": "cjs/index.js",
-  "module": "es/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es/index.js",
   "repository": {
     "directory": "packages/cascara",
     "type": "git",
@@ -12,8 +12,7 @@
     "access": "public"
   },
   "files": [
-    "cjs",
-    "es"
+    "dist"
   ],
   "license": "MIT",
   "sideEffects": false,

--- a/packages/cascara/package.json
+++ b/packages/cascara/package.json
@@ -31,7 +31,7 @@
     "semantic-ui-react": "^0.88.2"
   },
   "scripts": {
-    "clean": "rm -rf dist && rm -rf cjs && rm -rf es",
+    "clean": "rm -rf dist",
     "build": "yarn clean && rollup -c",
     "watch": "rollup -c -w"
   },


### PR DESCRIPTION
No new components. This PR updates the Circle CI build configuration to make sure we are also testing the docs to confirm they are not broken between each PR. As of now, we would only be able to tell if the docs are broken when we go to merge to the main branch and find that the build has failed at that stage.

Build phases are now:

1. install
2. lint, test
3. build cosmos, docs, cascara

The build stages are not published anywhere. They are just intended to have the build phases run and if anything is broken, the builds will fail and alert us.