### PR TITLE
Docs now support index and principles section

### DIFF
--- a/docs/src/components/Main/Main.js
+++ b/docs/src/components/Main/Main.js
@@ -1,0 +1,25 @@
+import { Admin } from '@espressive/cascara';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useRouter } from 'next/router';
+
+const Main = ({ children, ...rest }) => {
+  const { query } = useRouter();
+
+  return (
+    <AnimatePresence exitBeforeEnter>
+      <Admin.Main {...rest}>
+        <motion.div
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          initial={{ opacity: 0 }}
+          key={query.slug}
+          style={{ padding: '1em' }}
+        >
+          {children}
+        </motion.div>
+      </Admin.Main>
+    </AnimatePresence>
+  );
+};
+
+export default Main;

--- a/docs/src/components/Main/index.js
+++ b/docs/src/components/Main/index.js
@@ -1,0 +1,1 @@
+export { default } from './Main';

--- a/docs/src/components/Nav/Nav.js
+++ b/docs/src/components/Nav/Nav.js
@@ -6,16 +6,59 @@ import NavSection from './NavSection';
 
 const docPath = (path) => path.replace('../packages/cascara/src', '/docs');
 
-const Nav = ({ mdxTree }) => {
+const dividerStyle = {
+  borderBottom: 'none',
+  borderTop: '1px solid var(--color-transparent-grey)',
+};
+const listStyle = { listStyle: 'none' };
+const activeListItemStyle = { listStyle: 'disc' };
+
+const Nav = ({ mdxTree, posts }) => {
   const router = useRouter();
 
   return (
     <Admin.Nav>
+      <ul style={listStyle}>
+        <li style={router?.asPath === '/' ? activeListItemStyle : undefined}>
+          <Link as='/' href='/'>
+            <a>Home</a>
+          </Link>
+        </li>
+      </ul>
+
+      <hr style={dividerStyle} />
+
+      <NavSection content='Principles' />
+      <ul style={listStyle}>
+        {posts?.map((post) => {
+          const fileAsPath = `/${post.filePath.replace(/\.mdx?$/, '')}`;
+
+          return (
+            // Do not render the index.mdx file here
+            post.filePath !== 'index.mdx' && (
+              <li
+                key={post.filePath}
+                style={
+                  router?.asPath === fileAsPath
+                    ? activeListItemStyle
+                    : undefined
+                }
+              >
+                <Link as={fileAsPath} href={`/[slug]`}>
+                  <a>{post?.data?.title || post.filePath}</a>
+                </Link>
+              </li>
+            )
+          );
+        })}
+      </ul>
+
+      <hr style={dividerStyle} />
       {mdxTree?.map((item) =>
         item.size ? (
           <Fragment key={item.name}>
             <NavSection content={item.name} />
-            <ul style={{ listStyle: 'none' }}>
+            <ul style={listStyle}>
               {item.children.map((item) => {
                 const activeComponent = router?.query?.mdx?.[1];
                 return item.size ? (
@@ -23,7 +66,7 @@ const Nav = ({ mdxTree }) => {
                     key={item.name}
                     style={
                       item.name === activeComponent
-                        ? { listStyle: 'disc' }
+                        ? activeListItemStyle
                         : undefined
                     }
                   >

--- a/docs/src/components/Nav/Nav.module.css
+++ b/docs/src/components/Nav/Nav.module.css
@@ -1,4 +1,5 @@
-.NavSection {
+h4.NavSection {
+  margin: 0.5em 0;
   text-transform: uppercase;
   padding: 0.5em 1em;
 }

--- a/docs/src/components/index.js
+++ b/docs/src/components/index.js
@@ -1,9 +1,10 @@
 import Code from './Code';
 import Header from './Header';
+import Main from './Main';
 import Nav from './Nav';
 import Placeholder from './Placeholder';
 import Playground from './Playground';
 import Props from './Props';
 import PropTable from './PropTable';
 
-export { Code, Header, Nav, Placeholder, Playground, Props, PropTable };
+export { Code, Header, Main, Nav, Placeholder, Playground, Props, PropTable };

--- a/docs/src/lib/mdxUtils.js
+++ b/docs/src/lib/mdxUtils.js
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
+// POSTS_PATH is useful when you want to get the path to a specific file
+export const POSTS_PATH = path.join(process.cwd(), '../packages/cascara/pages');
+
+// postFilePaths is the list of all mdx files inside the POSTS_PATH directory
+export const postFilePaths = fs
+  .readdirSync(POSTS_PATH)
+  // Only include md(x) files
+  .filter((path) => /\.mdx?$/.test(path));

--- a/docs/src/pages/[slug].js
+++ b/docs/src/pages/[slug].js
@@ -1,0 +1,81 @@
+import hydrate from 'next-mdx-remote/hydrate';
+import Head from 'next/head';
+import { POSTS_PATH, postFilePaths } from '../lib/mdxUtils';
+import getMDXTree from '../lib/getMDXTree';
+import MDX_COMPONENTS from '../lib/MDX_COMPONENTS';
+import MDX_OPTIONS from '../lib/MDX_OPTIONS';
+
+export default function PostPage({ source, frontMatter }) {
+  const content = hydrate(source, { components: MDX_COMPONENTS });
+  return (
+    <>
+      <Head>
+        <title>{frontMatter.title} - Cascara</title>
+        <meta
+          content={
+            frontMatter?.description || "Espressive's Functional Design System"
+          }
+          key='description'
+          name='description'
+        />
+        <meta content='width=device-width, initial-scale=1.0' name='viewport' />
+      </Head>
+
+      <h1>
+        {frontMatter.title || 'PLEASE ADD A TITLE TO YOUR MDX FRONTMATTER'}
+      </h1>
+      {content}
+    </>
+  );
+}
+
+export const getStaticPaths = async () => {
+  const paths = postFilePaths
+    // Remove file extensions for page paths
+    .map((path) => path.replace(/\.mdx?$/, ''))
+    // Map the path into the static paths object required by Next.js
+    .map((slug) => ({ params: { slug } }));
+
+  return {
+    fallback: false,
+    paths,
+  };
+};
+
+export const getStaticProps = async ({ params }) => {
+  const fs = require('fs');
+  const path = require('path');
+  const matter = require('gray-matter');
+  const renderToString = require('next-mdx-remote/render-to-string');
+
+  const postFilePath = path.join(POSTS_PATH, `${params.slug}.mdx`);
+  const source = fs.readFileSync(postFilePath);
+
+  const posts = postFilePaths.map((filePath) => {
+    const source = fs.readFileSync(path.join(POSTS_PATH, filePath));
+    const { content, data } = matter(source);
+
+    return {
+      content,
+      data,
+      filePath,
+    };
+  });
+
+  const { content, data } = matter(source);
+
+  const mdxSource = await renderToString(content, {
+    components: MDX_COMPONENTS,
+    mdxOptions: MDX_OPTIONS,
+    scope: data,
+  });
+
+  return {
+    props: {
+      frontMatter: data,
+      mdxTree: getMDXTree(),
+      posts,
+      source: mdxSource,
+    },
+  };
+};

--- a/docs/src/pages/[slug].js
+++ b/docs/src/pages/[slug].js
@@ -31,6 +31,8 @@ export default function PostPage({ source, frontMatter }) {
 
 export const getStaticPaths = async () => {
   const paths = postFilePaths
+    // Do not generate a path for the index file
+    .filter((path) => path !== 'index.mdx')
     // Remove file extensions for page paths
     .map((path) => path.replace(/\.mdx?$/, ''))
     // Map the path into the static paths object required by Next.js

--- a/docs/src/pages/_app.js
+++ b/docs/src/pages/_app.js
@@ -2,7 +2,7 @@ import '@espressive/legacy-css';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { Admin } from '@espressive/cascara';
-import { Header, Nav, PropTable } from '../components';
+import { Header, Main, Nav, PropTable } from '../components';
 
 // NOTE: Anything in the <Head> here is esentially a fallback. These tags can
 // be overridden at the page level. <meta> type tags will need a key added
@@ -36,9 +36,9 @@ function MyApp({ Component, pageProps }) {
         }
         header={<Header {...pageProps} />}
         main={
-          <Admin.Main>
+          <Main>
             <Component {...pageProps} />
-          </Admin.Main>
+          </Main>
         }
         nav={<Nav {...pageProps} />}
       />

--- a/docs/src/pages/docs/[[...mdx]].js
+++ b/docs/src/pages/docs/[[...mdx]].js
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { POSTS_PATH, postFilePaths } from '../../lib/mdxUtils';
 import MDX_COMPONENTS from '../../lib/MDX_COMPONENTS';
 import MDX_OPTIONS from '../../lib/MDX_OPTIONS';
 import getMDXTree from '../../lib/getMDXTree';
@@ -78,7 +79,6 @@ const Doc = ({ mdxDirSource }) => {
           // Technically works. But really this should be at the router.query.doc
           // level and the overall page should have its own transition.
           key={JSON.stringify(router)}
-          style={{ padding: '1em' }}
         >
           {mdxActive}
         </motion.div>
@@ -161,6 +161,17 @@ export const getStaticProps = async ({ params }) => {
     })
   );
 
+  const posts = postFilePaths.map((filePath) => {
+    const source = fs.readFileSync(path.join(POSTS_PATH, filePath));
+    const { content, data } = matter(source);
+
+    return {
+      content,
+      data,
+      filePath,
+    };
+  });
+
   return {
     props: {
       mdxDirFiles,
@@ -169,6 +180,7 @@ export const getStaticProps = async ({ params }) => {
       params: {
         mdx: [],
       },
+      posts,
     },
     // Keep this here for updates to the MDX file
     revalidate: 1,

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,24 +1,48 @@
+import hydrate from 'next-mdx-remote/hydrate';
 import getMDXTree from '../lib/getMDXTree';
+import { POSTS_PATH, postFilePaths } from '../lib/mdxUtils';
+import MDX_COMPONENTS from '../lib/MDX_COMPONENTS';
+import MDX_OPTIONS from '../lib/MDX_OPTIONS';
 
-// NOTE: Still need to figure out what shows here and how we
-// manage it. For now all of the fallback <Head> tags in _app
-// render for this page.
-
-export default function Home({ mdxTree }) {
-  return (
-    <details style={{ padding: '1em' }}>
-      <summary>mdxTree</summary>
-      <pre>
-        <code>{JSON.stringify(mdxTree, null, '  ')}</code>
-      </pre>
-    </details>
-  );
+export default function Home({ source, frontMatter }) {
+  const content = hydrate(source, { components: MDX_COMPONENTS });
+  return content;
 }
 
 export async function getStaticProps() {
+  const fs = require('fs');
+  const path = require('path');
+  const matter = require('gray-matter');
+  const renderToString = require('next-mdx-remote/render-to-string');
+
+  const postFilePath = path.join(POSTS_PATH, 'index.mdx');
+  const source = fs.readFileSync(postFilePath);
+
+  const posts = postFilePaths.map((filePath) => {
+    const source = fs.readFileSync(path.join(POSTS_PATH, filePath));
+    const { content, data } = matter(source);
+
+    return {
+      content,
+      data,
+      filePath,
+    };
+  });
+
+  const { content, data } = matter(source);
+
+  const mdxSource = await renderToString(content, {
+    components: MDX_COMPONENTS,
+    mdxOptions: MDX_OPTIONS,
+    scope: data,
+  });
+
   return {
     props: {
+      frontMatter: data,
       mdxTree: getMDXTree(),
+      posts,
+      source: mdxSource,
     },
     // Keep this here for updates to the MDX files
     revalidate: 1,

--- a/packages/cascara/pages/getting-started.mdx
+++ b/packages/cascara/pages/getting-started.mdx
@@ -1,0 +1,5 @@
+---
+title: Getting Started
+---
+
+Let's see if this works.

--- a/packages/cascara/pages/index.mdx
+++ b/packages/cascara/pages/index.mdx
@@ -1,0 +1,5 @@
+# Cascara
+
+This should be the main page that shows in the docs
+
+Okay cool

--- a/packages/cascara/pages/public-api-components.mdx
+++ b/packages/cascara/pages/public-api-components.mdx
@@ -1,0 +1,5 @@
+---
+title: Public API Components
+---
+
+This should be the main page that shows in the docs

--- a/packages/cascara/src/ui/Button/Button.doc.mdx
+++ b/packages/cascara/src/ui/Button/Button.doc.mdx
@@ -18,7 +18,7 @@ title: A button can display content
 title: A button can be fluid
 ---
 
-<Button fluid />
+<Button content='fluid' fluid />
 ```
 
 ```jsx


### PR DESCRIPTION
## New Component Checklist

- [x] Includes unit tests for _ALL_ required FDS use cases
- [x] Does not mute any top level API props in React
- [x] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [x] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node
