### PR TITLE
FDS-92 Remove the now incorrect left padding inside transparent inputs

### DIFF
--- a/utils/legacy-css/src/css/semantic.min.css
+++ b/utils/legacy-css/src/css/semantic.min.css
@@ -9469,7 +9469,6 @@ img.ui.bordered.image {
 .ui.transparent.input input {
   border-color: transparent !important;
   background-color: transparent !important;
-  padding: 0 0.51785714em 0.625em !important;
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
 } /*!


### PR DESCRIPTION
All Semantic UI inputs that were `transparent` had a previously customized padding to match the padding to the labels which we removed in the last update. This PR removes that custom padding, restoring the original lack of left padding on transparent inputs to make these inputs align with the label.
