### PR TITLE
FDS-91 - Fix checkbox not resetting to the original value if canceled

### DIFF
--- a/packages/cascara/src/modules/ActionEdit/ActionEdit.js
+++ b/packages/cascara/src/modules/ActionEdit/ActionEdit.js
@@ -47,7 +47,6 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
       }
     );
 
-    reset();
     setIsEditing(false);
   };
 
@@ -59,6 +58,10 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
   };
 
   const handleEdit = () => {
+    /**
+     * FDS-91: We are resetting the form with whatever is in record.
+     * We don't know if this is the best way to do it in React. */
+    reset({ ...record });
     onAction(
       // fake target
       {
@@ -90,31 +93,30 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
   return isEditing ? (
     <>
       <Button
+        {...cancelTestId}
         className='ui negative icon button'
-        loading={isSubmitting}
+        disabled={isSubmitting}
         onClick={handleCancel}
         type='button'
-        {...cancelTestId}
       >
         <Icon name='delete' />
       </Button>
       <Button
+        {...saveTestId}
         className='ui positive icon button'
-        disabled={!isDirty}
-        loading={isSubmitting}
+        disabled={!isDirty || isSubmitting}
         onClick={handleSubmit(onSubmit)}
         type='button'
-        {...saveTestId}
       >
         <Icon name='check' />
       </Button>
     </>
   ) : (
     <Button
+      {...editTestId}
       className='ui basic button'
       onClick={handleEdit}
       type='button'
-      {...editTestId}
     >
       {editLabel}
     </Button>

--- a/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
+++ b/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react';
-import { Checkbox } from 'reakit/Checkbox';
+import { Checkbox, useCheckboxState } from 'reakit/Checkbox';
 import pt from 'prop-types';
+
 import { ModuleContext } from '../context';
-import useToggle from '../../hooks/useToggle';
 import styles from '../DataModule.module.scss';
 
 import ErrorBoundary from '../../shared/ErrorBoundary';
@@ -34,22 +34,20 @@ const DataCheckbox = ({
   const { isEditing, formMethods, record } = useContext(ModuleContext);
   const finalValue =
     attribute && record
-      ? Boolean(getAttributeValueFromRecord(attribute, record))
-      : Boolean(value);
-  const [isChecked, setIsChecked] = useToggle(finalValue);
+      ? getAttributeValueFromRecord(attribute, record)
+      : value;
+  const checkbox = useCheckboxState({ state: Boolean(finalValue) });
 
   const renderEditing = (
     <label htmlFor={label}>
       {isLabeled && label && <span className={styles.Label}>{label}</span>}
       <Checkbox
         {...rest}
-        checked={isChecked}
+        {...checkbox}
         className={styles.Input}
         id={label}
         name={attribute || label}
-        onClick={setIsChecked}
         ref={formMethods?.register}
-        type='checkbox'
       />
       {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
     </label>

--- a/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
+++ b/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
@@ -34,9 +34,9 @@ const DataCheckbox = ({
   const { isEditing, formMethods, record } = useContext(ModuleContext);
   const finalValue =
     attribute && record
-      ? getAttributeValueFromRecord(attribute, record)
-      : value;
-  const [isChecked, setIsChecked] = useToggle(Boolean(finalValue));
+      ? Boolean(getAttributeValueFromRecord(attribute, record))
+      : Boolean(value);
+  const [isChecked, setIsChecked] = useToggle(finalValue);
 
   const renderEditing = (
     <label htmlFor={label}>
@@ -59,10 +59,10 @@ const DataCheckbox = ({
     <span>
       <span
         className={styles.Input}
-        data-checked={isChecked ? true : undefined}
+        data-checked={finalValue ? true : undefined}
         {...rest}
       >
-        {value}
+        {finalValue}
       </span>
       {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
     </span>


### PR DESCRIPTION
The checkbox module in `display` mode was using the `isChecked` value from its `local state`, which is incorrect. The value to  `display` should always come from the actual data,  as it is the only source of truth.

![x8Gr47Uy9A](https://user-images.githubusercontent.com/13924868/102836435-ffd61700-43be-11eb-9004-d2ea8541dd68.gif)

This PR fixes the bug by implementing the `useCheckboxState` hook for the checkbox' state as well as other minor changes.

![FDS-91 fix](https://user-images.githubusercontent.com/13924868/102836450-0c5a6f80-43bf-11eb-8aca-0e0dd53fc396.gif)

During our pair-programing session we discovered some other issues which we'll address in future PRs, once the relevant tasks are created.