### PR TITLE
FDS-94 - Remove the getAttributeValueFromRecord function from modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@rollup/plugin-node-resolve": "9.0.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "10.4.7",
+    "@testing-library/user-event": "12.6.0",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
     "babel-eslint": "10.1.0",

--- a/packages/cascara/src/modules/ActionButton/ActionButton.js
+++ b/packages/cascara/src/modules/ActionButton/ActionButton.js
@@ -5,15 +5,20 @@ import { ModuleContext } from '../context';
 import { Button } from 'reakit';
 
 const propTypes = {
+  /** Every action can have a name */
   actionName: pt.string,
+  /** Test ids to ease testing */
+  'data-testid': pt.string,
+  /** Presents the button without a label. NOT USER CONFIGURABLE */
   isLabeled: pt.bool,
+  /** An action needs to have a unique label relative to its context */
   label: pt.string,
 };
 
 const ActionButton = ({
+  actionName,
   isLabeled = false,
   label = 'ActionButton',
-  actionName,
   ...rest
 }) => {
   const { isEditing, onAction, record } = useContext(ModuleContext);

--- a/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
+++ b/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
@@ -6,7 +6,6 @@ import { ModuleContext } from '../context';
 import styles from '../DataModule.module.scss';
 
 import ErrorBoundary from '../../shared/ErrorBoundary';
-import { getAttributeValueFromRecord } from '../../shared/recordUtils';
 
 const propTypes = {
   /** A module can have an Attribute, which will be used as form field name */
@@ -31,12 +30,8 @@ const DataCheckbox = ({
   value,
   ...rest
 }) => {
-  const { isEditing, formMethods, record } = useContext(ModuleContext);
-  const finalValue =
-    attribute && record
-      ? getAttributeValueFromRecord(attribute, record)
-      : value;
-  const checkbox = useCheckboxState({ state: Boolean(finalValue) });
+  const { isEditing, formMethods } = useContext(ModuleContext);
+  const checkbox = useCheckboxState({ state: Boolean(value) });
 
   const renderEditing = (
     <label htmlFor={label}>
@@ -57,10 +52,10 @@ const DataCheckbox = ({
     <span>
       <span
         className={styles.Input}
-        data-checked={finalValue ? true : undefined}
+        data-checked={value ? true : undefined}
         {...rest}
       >
-        {finalValue}
+        {value}
       </span>
       {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
     </span>

--- a/packages/cascara/src/modules/DataEmail/DataEmail.js
+++ b/packages/cascara/src/modules/DataEmail/DataEmail.js
@@ -5,7 +5,6 @@ import { ModuleContext } from '../context';
 import styles from '../DataModule.module.scss';
 
 import ErrorBoundary from '../../shared/ErrorBoundary';
-import { getAttributeValueFromRecord } from '../../shared/recordUtils';
 
 const propTypes = {
   /** A module can have an Attribute, which will be used as form field name */
@@ -30,11 +29,7 @@ const DataEmail = ({
   value,
   ...rest
 }) => {
-  const { isEditing, formMethods, record } = useContext(ModuleContext);
-  const finalValue =
-    attribute && record
-      ? getAttributeValueFromRecord(attribute, record)
-      : value;
+  const { isEditing, formMethods } = useContext(ModuleContext);
 
   const renderEditing = (
     <label htmlFor={label}>
@@ -42,7 +37,7 @@ const DataEmail = ({
       <Input
         {...rest}
         className={styles.Input}
-        defaultValue={finalValue}
+        defaultValue={value}
         id={label}
         name={attribute || label}
         ref={formMethods?.register}
@@ -55,7 +50,7 @@ const DataEmail = ({
     <span>
       {label && isLabeled && <span className={styles.Label}>{label}</span>}
       <span className={styles.Input} {...rest}>
-        {finalValue}
+        {value}
       </span>
     </span>
   );

--- a/packages/cascara/src/modules/DataNumber/DataNumber.js
+++ b/packages/cascara/src/modules/DataNumber/DataNumber.js
@@ -5,7 +5,6 @@ import { ModuleContext } from '../context';
 import styles from '../DataModule.module.scss';
 
 import ErrorBoundary from '../../shared/ErrorBoundary';
-import { getAttributeValueFromRecord } from '../../shared/recordUtils';
 
 const propTypes = {
   /** A module can have an Attribute, which will be used as form field name */
@@ -30,11 +29,7 @@ const DataNumber = ({
   value,
   ...rest
 }) => {
-  const { isEditing, formMethods, record } = useContext(ModuleContext);
-  const finalValue =
-    attribute && record
-      ? getAttributeValueFromRecord(attribute, record)
-      : value;
+  const { isEditing, formMethods } = useContext(ModuleContext);
 
   const renderEditing = (
     <label htmlFor={label}>
@@ -42,7 +37,7 @@ const DataNumber = ({
       <Input
         {...rest}
         className={styles.Input}
-        defaultValue={finalValue}
+        defaultValue={value}
         id={label}
         name={attribute || label}
         ref={formMethods?.register}
@@ -55,7 +50,7 @@ const DataNumber = ({
     <span>
       {label && isLabeled && <span className={styles.Label}>{label}</span>}
       <span className={styles.Input} {...rest}>
-        {finalValue}
+        {value}
       </span>
     </span>
   );

--- a/packages/cascara/src/modules/DataRadio/DataRadio.js
+++ b/packages/cascara/src/modules/DataRadio/DataRadio.js
@@ -5,7 +5,6 @@ import { ModuleContext } from '../context';
 import styles from '../DataModule.module.scss';
 
 import ErrorBoundary from '../../shared/ErrorBoundary';
-import { getAttributeValueFromRecord } from '../../shared/recordUtils';
 
 const propTypes = {
   /** A module can have an Attribute, which will be used as form field name */
@@ -31,12 +30,8 @@ const DataRadio = ({
   value,
   ...rest
 }) => {
-  const { isEditing, formMethods, record } = useContext(ModuleContext);
-  const finalValue =
-    attribute && record
-      ? getAttributeValueFromRecord(attribute, record)
-      : value;
-  const radio = useRadioState({ state: finalValue });
+  const { isEditing, formMethods } = useContext(ModuleContext);
+  const radio = useRadioState({ state: value });
 
   const renderRadio = (option) => (
     <label htmlFor={option.label}>
@@ -64,7 +59,7 @@ const DataRadio = ({
     >
       {options
         ? options.map((option) => renderRadio(option))
-        : renderRadio(finalValue)}
+        : renderRadio(value)}
     </RadioGroup>
   );
 
@@ -73,7 +68,7 @@ const DataRadio = ({
       <div className={styles.Radio}>
         <span>
           <span className={styles.Input} {...rest}>
-            {finalValue}
+            {value}
           </span>
           {label && isLabeled && (
             <span className={styles.LabelText}>{label}</span>

--- a/packages/cascara/src/modules/DataSelect/DataSelect.js
+++ b/packages/cascara/src/modules/DataSelect/DataSelect.js
@@ -5,7 +5,6 @@ import { ModuleContext } from '../context';
 import styles from '../DataModule.module.scss';
 
 import ErrorBoundary from '../../shared/ErrorBoundary';
-import { getAttributeValueFromRecord } from '../../shared/recordUtils';
 
 const propTypes = {
   /** A module can have an Attribute, which will be used as form field name */
@@ -31,11 +30,7 @@ const DataSelect = ({
   value,
   ...rest
 }) => {
-  const { isEditing, formMethods, record } = useContext(ModuleContext);
-  const finalValue =
-    attribute && record
-      ? getAttributeValueFromRecord(attribute, record)
-      : value;
+  const { isEditing, formMethods } = useContext(ModuleContext);
 
   const renderEditing = (
     <label htmlFor={label}>
@@ -44,7 +39,7 @@ const DataSelect = ({
         {...rest}
         as='select'
         className={styles.Input}
-        defaultValue={finalValue}
+        defaultValue={value}
         id={label}
         name={attribute || label}
         ref={formMethods?.register}
@@ -56,7 +51,7 @@ const DataSelect = ({
             </option>
           ))
         ) : (
-          <option value={finalValue}>{finalValue}</option>
+          <option value={value}>{value}</option>
         )}
       </Input>
     </label>
@@ -66,7 +61,7 @@ const DataSelect = ({
     <span>
       {label && isLabeled && <span className={styles.Label}>{label}</span>}
       <span className={styles.Input} {...rest}>
-        {finalValue}
+        {value}
       </span>
     </span>
   );

--- a/packages/cascara/src/modules/DataText/DataText.js
+++ b/packages/cascara/src/modules/DataText/DataText.js
@@ -5,7 +5,6 @@ import { ModuleContext } from '../context';
 import styles from '../DataModule.module.scss';
 
 import ErrorBoundary from '../../shared/ErrorBoundary';
-import { getAttributeValueFromRecord } from '../../shared/recordUtils';
 
 const propTypes = {
   /** A module can have an Attribute, which will be used as form field name */
@@ -30,11 +29,7 @@ const DataText = ({
   value,
   ...rest
 }) => {
-  const { isEditing, formMethods, record } = useContext(ModuleContext);
-  const finalValue =
-    attribute && record
-      ? getAttributeValueFromRecord(attribute, record)
-      : value;
+  const { isEditing, formMethods } = useContext(ModuleContext);
 
   const renderEditing = (
     <label htmlFor={label}>
@@ -42,7 +37,7 @@ const DataText = ({
       <Input
         {...rest}
         className={styles.Input}
-        defaultValue={finalValue}
+        defaultValue={value}
         id={label}
         name={attribute || label}
         ref={formMethods?.register}
@@ -55,7 +50,7 @@ const DataText = ({
     <span>
       {label && isLabeled && <span className={styles.Label}>{label}</span>}
       <span className={styles.Input} {...rest}>
-        {finalValue}
+        {value}
       </span>
     </span>
   );

--- a/packages/cascara/src/modules/DataTextArea/DataTextArea.js
+++ b/packages/cascara/src/modules/DataTextArea/DataTextArea.js
@@ -6,7 +6,6 @@ import { ModuleContext } from '../context';
 import styles from '../DataModule.module.scss';
 
 import ErrorBoundary from '../../shared/ErrorBoundary';
-import { getAttributeValueFromRecord } from '../../shared/recordUtils';
 
 const propTypes = {
   /** A module can have an Attribute, which will be used as form field name */
@@ -31,11 +30,7 @@ const DataTextArea = ({
   value,
   ...rest
 }) => {
-  const { isEditing, formMethods, record } = useContext(ModuleContext);
-  const finalValue =
-    attribute && record
-      ? getAttributeValueFromRecord(attribute, record)
-      : value;
+  const { isEditing, formMethods } = useContext(ModuleContext);
 
   const renderEditing = (
     // eslint-disable-next-line jsx-a11y/label-has-for
@@ -45,7 +40,7 @@ const DataTextArea = ({
         {...rest}
         as={TextareaAutosize}
         className={styles.Input}
-        defaultValue={finalValue}
+        defaultValue={value}
         id={label}
         name={attribute || label}
         ref={formMethods?.register}
@@ -57,7 +52,7 @@ const DataTextArea = ({
     <span>
       {label && isLabeled && <span className={styles.Label}>{label}</span>}
       <span className={styles.Input} {...rest}>
-        {finalValue}
+        {value}
       </span>
     </span>
   );

--- a/packages/cascara/src/modules/ModuleError/ModuleError.js
+++ b/packages/cascara/src/modules/ModuleError/ModuleError.js
@@ -8,7 +8,7 @@ const propTypes = {
 };
 
 const ModuleError = ({ moduleName, moduleOptions }) => {
-  const message = `${moduleName} is not a invalid value for module. Try using one of [${moduleOptions.join(
+  const message = `${moduleName} is not a valid value for module. Try using one of [${moduleOptions.join(
     ', '
   )}]`;
   // eslint-disable-next-line no-console
@@ -16,7 +16,7 @@ const ModuleError = ({ moduleName, moduleOptions }) => {
 
   return (
     <div className={styles.Error} data-testid={'module-error'}>
-      Invalid module name
+      {message}
     </div>
   );
 };

--- a/packages/cascara/src/ui/Table/Table.test.snap
+++ b/packages/cascara/src/ui/Table/Table.test.snap
@@ -2,8 +2,6 @@
 
 exports[`Table component tree default props 1`] = `<div />`;
 
-exports[`Table component tree no row actions 1`] = `<div />`;
-
 exports[`Table component tree snapshot test 1`] = `
 <div>
   <form>
@@ -16730,3 +16728,5 @@ exports[`Table component tree snapshot test 1`] = `
   </form>
 </div>
 `;
+
+exports[`Table component tree without row actions 1`] = `<div />`;

--- a/packages/cascara/src/ui/Table/TableRow.js
+++ b/packages/cascara/src/ui/Table/TableRow.js
@@ -8,8 +8,7 @@ import { ModuleContext } from '../../modules/context';
 
 import ActionBar from './ActionBar';
 
-// Data
-// @manu: let's document this one
+// todo @manu: let's document this one
 // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md
 
 import ModuleError from '../../modules/ModuleError';
@@ -68,11 +67,12 @@ const TableRow = ({ config = {}, record = {} }) => {
   const rowCells = columns.map((column) => {
     const { module, isLabeled, ...rest } = column;
     const Module = dataModules[module];
+    const moduleValue = record[column.attribute];
 
     return (
       <td className={styles.Cell} key={column.attribute}>
         {Module ? (
-          <Module isLabeled={false} {...rest} />
+          <Module {...rest} isLabeled={false} value={moduleValue} />
         ) : (
           <ModuleError moduleName={module} moduleOptions={dataModuleOptions} />
         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2283,7 +2283,7 @@
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@espressive/cascara@file:packages/cascara":
-  version "0.2.9"
+  version "0.2.11"
   dependencies:
     "@babel/runtime" "7.11.2"
     "@nivo/bar" "0.61.0"
@@ -4089,6 +4089,13 @@
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.17.1"
+
+"@testing-library/user-event@12.6.0":
+  version "12.6.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.6.0.tgz#2d0229e399eb5a0c6c112e848611432356cac886"
+  integrity sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 "@types/aria-query@^4.2.0":
   version "4.2.0"


### PR DESCRIPTION
The **getAttributeValueFromRecord** function was acting as a _field accessor_ for the modules, this is not what we want.

This PR, if merged, will remove this unnecessary accessor function. The _value_ is now provided to the module as a _prop_ when Table cells are created. The test suite has also been improved, adding a test case to effectively validate any changes in the record.

cheers