### PR TITLE
FDS-77 - Bump Next to the latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   install:
     executor:
       name: node/default
-      tag: '12.20.0'
+      tag: '12.0.0'
     steps:
       - checkout
       - node/install-packages:
@@ -25,7 +25,7 @@ jobs:
   lint:
     executor:
       name: node/default
-      tag: '12.20.0'
+      tag: '12.0.0'
     steps:
       - restore_cache:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
@@ -44,7 +44,7 @@ jobs:
   test:
     executor:
       name: node/default
-      tag: '12.20.0'
+      tag: '12.0.0'
     steps:
       - restore_cache:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
@@ -65,7 +65,7 @@ jobs:
   build-cascara:
     executor:
       name: node/default
-      tag: '12.20.0'
+      tag: '12.0.0'
     steps:
       - restore_cache:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
@@ -87,7 +87,7 @@ jobs:
   build-cosmos:
     executor:
       name: node/default
-      tag: '12.20.0'
+      tag: '12.0.0'
     steps:
       - restore_cache:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
@@ -105,7 +105,7 @@ jobs:
   build-docs:
     executor:
       name: node/default
-      tag: '12.20.0'
+      tag: '12.0.0'
     steps:
       - restore_cache:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@3.0.1
+  node: circleci/node@4.0.1
   slack: circleci/slack@3.4.2
 
 jobs:
@@ -113,7 +113,7 @@ jobs:
           key: cascara-CASCARA_RUNTIMES-{{ .Revision }}-{{ checksum "yarn.lock" }}
       - run:
           name: Build Docs
-          command: yarn docs build
+          command: yarn cascara build && yarn docs build
       - slack/status:
           fail_only: true
           include_project_field: false

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "@espressive/cascara": "file:../packages/cascara",
     "@espressive/legacy-css": "file:../utils/legacy-css",
     "framer-motion": "2.5.5",
-    "next": "9.5.4",
+    "next": "10.0.5",
     "next-mdx-remote": "1.0.0",
     "react": "16.13.1",
     "react-docgen": "5.3.1",


### PR DESCRIPTION
Hi team, 

We are bumping Next to its latest release. This build will probably fail because we still need to merge [FDS-76 - use the correct version of nodejs for vercel (12.x)](https://github.com/Espressive/cascara/pull/133) for Vercel to pick the new config up.

Cheers