### PR TITLE
FDS-95 - Prevent multiple rows from entering in edit mode

### DIFF
--- a/packages/cascara/src/modules/ActionEdit/ActionEdit.js
+++ b/packages/cascara/src/modules/ActionEdit/ActionEdit.js
@@ -17,11 +17,20 @@ const propTypes = {
 };
 
 const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
-  const { isEditing, setIsEditing, formMethods, record, onAction } = useContext(
-    ModuleContext
-  );
+  const {
+    idOfRecordInEditMode,
+    isEditing,
+    enterEditMode,
+    exitEditMode,
+    formMethods,
+    record,
+    onAction,
+    uniqueIdAttribute,
+  } = useContext(ModuleContext);
   const { handleSubmit, formState, reset } = formMethods;
   const { isDirty, isSubmitting } = formState;
+  const recordId = record[uniqueIdAttribute];
+  const whenAnotherRowIsEditing = Boolean(idOfRecordInEditMode);
 
   /**
    * this seems like ugly, we need to find a better way
@@ -47,7 +56,7 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
       }
     );
 
-    setIsEditing(false);
+    exitEditMode();
   };
 
   const handleCancel = () => {
@@ -72,7 +81,7 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
       }
     );
 
-    setIsEditing(true);
+    enterEditMode(recordId);
   };
 
   const onSubmit = (data) => {
@@ -87,7 +96,7 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
       }
     );
 
-    setIsEditing(false);
+    exitEditMode();
   };
 
   return isEditing ? (
@@ -115,6 +124,7 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
     <Button
       {...editTestId}
       className='ui basic button'
+      disabled={whenAnotherRowIsEditing}
       onClick={handleEdit}
       type='button'
     >

--- a/packages/cascara/src/ui/Table/context/RowProvider.js
+++ b/packages/cascara/src/ui/Table/context/RowProvider.js
@@ -4,16 +4,24 @@ import { ModuleContext, ModuleProvider } from '../../../modules/context';
 const RowProvider = ({ children, value, ...props }) => {
   const grandparentValues = useContext(ModuleContext);
 
-  // Here we need to not pass the isEditing and setIsEditing values from grandparent which
-  // will override what is happening in the ModuleProvider we pass mergedValues into. This
-  // way the row provider itself can have its own isEditing. This is also a good place for
-  // us to control how these values get set if the overall table is getting edited on
-  // another row.
-  const { isEditing, setIsEditing, ...rest } = grandparentValues;
+  const {
+    idOfRecordInEditMode,
+    uniqueIdAttribute,
+    ...rest
+  } = grandparentValues;
+  const { record } = value;
+  const recordId = record[uniqueIdAttribute];
+
+  // isEditing is based on wether the record ids are the same
+  const isEditing = recordId === idOfRecordInEditMode;
+
   const mergedValues = {
     ...ModuleContext.defaultValue,
     ...rest,
     ...value,
+    idOfRecordInEditMode,
+    isEditing,
+    uniqueIdAttribute,
   };
 
   return (

--- a/packages/cascara/src/ui/Table/context/TableProvider.js
+++ b/packages/cascara/src/ui/Table/context/TableProvider.js
@@ -1,37 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ModuleContext, ModuleProvider } from '../../../modules/context';
 import { useForm } from 'react-hook-form';
 
 const TableProvider = ({ children, value, ...props }) => {
+  const [idOfRecordInEditMode, setIdOfRecordInEditMode] = useState(null);
   const formMethods = useForm();
-  // const { handleSubmit } = formMethods;
 
-  // const onSubmit = (data) => {
-  //   // eslint-disable-next-line no-console
-  //   console.table(data);
+  function enterEditMode(recordId) {
+    setIdOfRecordInEditMode(recordId);
+  }
 
-  //   /** @brian:
-  //    *
-  //    * I am thinking on a way for us to derive the type of action
-  //    * to rise here, depending on which mode we are in:
-  //    *
-  //    * isEditing -> update
-  //    * isCreating -> create
-  //    */
-  //   value.onAction('submit', {
-  //     /**
-  //      * We cannot pass the whole record because it doesn't
-  //      * exist in this context, it is added downstream.
-  //      */
-  //     // ...value.record,
-  //     ...data,
-  //   });
-  // };
+  function exitEditMode() {
+    setIdOfRecordInEditMode(null);
+  }
 
   const mergedValues = {
     ...ModuleContext.defaultValue,
     ...value,
+    enterEditMode,
+    exitEditMode,
     formMethods,
+    idOfRecordInEditMode,
   };
 
   return (


### PR DESCRIPTION
Hi team,

As of today, all reccords in a Table can be edited at the same time, which causes lots of issues. The root cause seems to be that the `isEditing` flag is scoped to the row, so every row is in charge of its edit state.

**The bug**
https://recordit.co/U8HRrG52bJ

The flag was replaced with the actual id of the record that is being edited, we also moved the flag and its setter functions to the upper `context`.

**The fix**
https://recordit.co/J6b3d6NLCj

I am sure there could be other ways to implement this, please feel free to propose any other approach.

Cheers.