### PR TITLE
FDS-15 Add support for Form to Cascara

### DIFF
--- a/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
+++ b/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
@@ -35,7 +35,7 @@ const DataCheckbox = ({
 
   const renderEditing = (
     <label htmlFor={label}>
-      {isLabeled && label && <span className={styles.Label}>{label}</span>}
+      {isLabeled && label && <span className={styles.LabelText}>{label}</span>}
       <Checkbox
         {...rest}
         {...checkbox}

--- a/packages/cascara/src/modules/DataEmail/DataEmail.js
+++ b/packages/cascara/src/modules/DataEmail/DataEmail.js
@@ -33,7 +33,7 @@ const DataEmail = ({
 
   const renderEditing = (
     <label htmlFor={label}>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <Input
         {...rest}
         className={styles.Input}
@@ -48,7 +48,7 @@ const DataEmail = ({
 
   const renderDisplay = (
     <span>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <span className={styles.Input} {...rest}>
         {value}
       </span>

--- a/packages/cascara/src/modules/DataModule.module.scss
+++ b/packages/cascara/src/modules/DataModule.module.scss
@@ -33,7 +33,6 @@ $module-background: #f0f0f0;
     display: inline-block;
     border: 1px solid transparent;
     width: 100%;
-    max-width: 60em;
     border-radius: $input-border-radius;
     transition: box-shadow 300ms ease-in-out;
   }
@@ -197,7 +196,8 @@ $module-background: #f0f0f0;
   background-color: #fcc;
   color: #900;
   border-radius: $module-border-radius;
-  margin-bottom: $masonry-gutter;
+  font-size: 0.875em;
+  font-family: monospace;
 
   h4 {
     margin-bottom: 0.5em;

--- a/packages/cascara/src/modules/DataNumber/DataNumber.js
+++ b/packages/cascara/src/modules/DataNumber/DataNumber.js
@@ -33,7 +33,7 @@ const DataNumber = ({
 
   const renderEditing = (
     <label htmlFor={label}>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <Input
         {...rest}
         className={styles.Input}
@@ -48,7 +48,7 @@ const DataNumber = ({
 
   const renderDisplay = (
     <span>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <span className={styles.Input} {...rest}>
         {value}
       </span>

--- a/packages/cascara/src/modules/DataSelect/DataSelect.js
+++ b/packages/cascara/src/modules/DataSelect/DataSelect.js
@@ -34,7 +34,7 @@ const DataSelect = ({
 
   const renderEditing = (
     <label htmlFor={label}>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <Input
         {...rest}
         as='select'
@@ -59,7 +59,7 @@ const DataSelect = ({
 
   const renderDisplay = (
     <span>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <span className={styles.Input} {...rest}>
         {value}
       </span>

--- a/packages/cascara/src/modules/DataText/DataText.js
+++ b/packages/cascara/src/modules/DataText/DataText.js
@@ -33,7 +33,7 @@ const DataText = ({
 
   const renderEditing = (
     <label htmlFor={label}>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <Input
         {...rest}
         className={styles.Input}
@@ -48,7 +48,7 @@ const DataText = ({
 
   const renderDisplay = (
     <span>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <span className={styles.Input} {...rest}>
         {value}
       </span>

--- a/packages/cascara/src/modules/DataTextArea/DataTextArea.js
+++ b/packages/cascara/src/modules/DataTextArea/DataTextArea.js
@@ -35,7 +35,7 @@ const DataTextArea = ({
   const renderEditing = (
     // eslint-disable-next-line jsx-a11y/label-has-for
     <label htmlFor={label}>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <Input
         {...rest}
         as={TextareaAutosize}
@@ -50,7 +50,7 @@ const DataTextArea = ({
 
   const renderDisplay = (
     <span>
-      {label && isLabeled && <span className={styles.Label}>{label}</span>}
+      {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <span className={styles.Input} {...rest}>
         {value}
       </span>

--- a/packages/cascara/src/ui/Form/Form.js
+++ b/packages/cascara/src/ui/Form/Form.js
@@ -71,11 +71,15 @@ const formFields = (display, data) => {
     // Check to see if we have a form module, which will probably only be a FormRow
     const FormModule = formModules[module];
 
-    return Boolean(FormModule) ? (
-      // TODO: We should concat the form ID with this row index for a more robust key value
-      <FormModule key={i}>{renderFields(field.fields)}</FormModule>
-    ) : (
-      renderField(field)
+    return (
+      <ErrorBoundary>
+        {Boolean(FormModule) ? (
+          // TODO: We should concat the form ID with this row index for a more robust key value
+          <FormModule {...field}>{renderFields(field.fields)}</FormModule>
+        ) : (
+          renderField(field)
+        )}
+      </ErrorBoundary>
     );
   });
 };

--- a/packages/cascara/src/ui/Form/Form.js
+++ b/packages/cascara/src/ui/Form/Form.js
@@ -1,12 +1,110 @@
 import React from 'react';
 import pt from 'prop-types';
+// import styles from './Form.module.scss';
+
+import ErrorBoundary from '../../shared/ErrorBoundary';
+import FormProvider from './context/FormProvider';
+import ModuleError from '../../modules/ModuleError';
+
+import { actionModules, dataModules } from '../../modules/ModuleKeys';
+import { formModules } from './modules';
+
+const formDataModules = { ...formModules, ...dataModules };
+const actionModuleOptions = Object.keys(actionModules);
+const dataModuleOptions = Object.keys(formDataModules);
 
 const propTypes = {
-  action: pt.string,
+  /** An object of modules to display.
+   *
+   * Every parameter in this object can potentially be rendered in the form. */
+  data: pt.shape({}),
+
+  /** The main configuration for your form. Here you can specify fields or rows of fields to display as well as the actions to take on the form itself. */
+  dataConfig: pt.shape({
+    /** Actions will be appended to each row, they'll appear as buttons. */
+    actions: pt.arrayOf(
+      pt.shape({
+        module: pt.oneOf(actionModuleOptions).isRequired,
+      })
+    ),
+
+    /** Here you can describe each of the visible columns in your table. */
+    display: pt.arrayOf(
+      pt.shape({
+        module: pt.oneOf(dataModuleOptions).isRequired,
+      })
+    ),
+  }).isRequired,
+
+  /** A form can start in an editing state */
+  isInitialEditing: pt.bool,
+
+  /** Event handler.
+   *
+   * An event handler you can pass to handle every event your table emits.*/
+  onAction: pt.func,
+
+  /** Unique ID Attribute.
+   *
+   * specifies the attribute that uniquely identifies every object in the 'data' array. */
+  uniqueIdAttribute: pt.string,
 };
 
-const Form = ({ action }) => {
-  return <form action={action} />;
+const formFields = (display, data) => {
+  const renderField = (field) => {
+    const { module, label, ...rest } = field;
+    const Module = dataModules[module];
+    const moduleValue = data[field.attribute];
+
+    return Module ? (
+      <Module {...rest} key={label} label={label} value={moduleValue} />
+    ) : (
+      <ModuleError moduleName={module} moduleOptions={dataModuleOptions} />
+    );
+  };
+
+  const renderFields = (fields) => fields.map((field) => renderField(field));
+
+  return display.map((field, i) => {
+    const { module } = field;
+
+    // Check to see if we have a form module, which will probably only be a FormRow
+    const FormModule = formModules[module];
+
+    return Boolean(FormModule) ? (
+      // TODO: We should concat the form ID with this row index for a more robust key value
+      <FormModule key={i}>{renderFields(field.fields)}</FormModule>
+    ) : (
+      renderField(field)
+    );
+  });
+};
+
+const Form = ({
+  data,
+  dataConfig,
+  onAction,
+  uniqueIdAttribute,
+  isInitialEditing = false,
+  ...rest
+}) => {
+  const { display } = dataConfig;
+  return (
+    <ErrorBoundary>
+      <FormProvider
+        value={{
+          data,
+          dataConfig,
+          isEditing: isInitialEditing,
+          onAction,
+          uniqueIdAttribute,
+        }}
+        {...rest}
+      >
+        {formFields(display, data)}
+      </FormProvider>
+    </ErrorBoundary>
+  );
 };
 
 Form.propTypes = propTypes;

--- a/packages/cascara/src/ui/Form/Form.module.scss
+++ b/packages/cascara/src/ui/Form/Form.module.scss
@@ -20,6 +20,7 @@
   .FormRow {
     display: grid;
     grid-gap: 1em;
-    grid-template-columns: repeat(auto-fit, minmax(10em, 1fr));
+    // This default column template is applied inline on the module itself
+    // grid-template-columns: repeat(auto-fit, minmax(10em, 1fr));
   }
 }

--- a/packages/cascara/src/ui/Form/Form.module.scss
+++ b/packages/cascara/src/ui/Form/Form.module.scss
@@ -1,0 +1,25 @@
+.Form {
+  margin-top: 1em;
+
+  & > * {
+    margin-bottom: 1em;
+  }
+}
+
+.FormRow {
+  margin: 0;
+  display: contents;
+
+  & > * {
+    margin-bottom: 1em;
+  }
+}
+
+// Need to standardize these breakpoints
+@media (min-width: 720px) {
+  .FormRow {
+    display: grid;
+    grid-gap: 1em;
+    grid-template-columns: repeat(auto-fit, minmax(10em, 1fr));
+  }
+}

--- a/packages/cascara/src/ui/Form/context/FormProvider.js
+++ b/packages/cascara/src/ui/Form/context/FormProvider.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ModuleContext, ModuleProvider } from '../../../modules/context';
+import styles from '../Form.module.scss';
 import { useForm } from 'react-hook-form';
 
 const FormProvider = ({ children, value, ...props }) => {
@@ -19,7 +20,9 @@ const FormProvider = ({ children, value, ...props }) => {
 
   return (
     <ModuleProvider value={mergedValues} {...props}>
-      <form onSubmit={handleSubmit(onSubmit)}>{children}</form>
+      <form className={styles.Form} onSubmit={handleSubmit(onSubmit)}>
+        {children}
+      </form>
     </ModuleProvider>
   );
 };

--- a/packages/cascara/src/ui/Form/context/index.js
+++ b/packages/cascara/src/ui/Form/context/index.js
@@ -1,1 +1,3 @@
-export { default } from './FormProvider';
+import FormProvider from './FormProvider';
+
+export { FormProvider };

--- a/packages/cascara/src/ui/Form/modules/FormRow.js
+++ b/packages/cascara/src/ui/Form/modules/FormRow.js
@@ -2,10 +2,25 @@ import React from 'react';
 import styles from '../Form.module.scss';
 import ErrorBoundary from '../../../shared/ErrorBoundary';
 
-const FormRow = ({ children }) => {
+const FormRow = ({ children, ratio }) => {
+  if (ratio && ratio.length !== children.length) {
+    throw new Error(
+      'The length of the ratio array must match the number of form row fields'
+    );
+  }
+
+  const columnRatio =
+    ratio?.map((col) => col + 'fr').join(' ') ||
+    'repeat(auto-fit, minmax(10em, 1fr))';
+
   return (
     <ErrorBoundary>
-      <div className={styles.FormRow}>{children}</div>
+      <div
+        className={styles.FormRow}
+        style={{ gridTemplateColumns: columnRatio }}
+      >
+        {children}
+      </div>
     </ErrorBoundary>
   );
 };

--- a/packages/cascara/src/ui/Form/modules/FormRow.js
+++ b/packages/cascara/src/ui/Form/modules/FormRow.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from '../Form.module.scss';
+import ErrorBoundary from '../../../shared/ErrorBoundary';
+
+const FormRow = ({ children }) => {
+  return (
+    <ErrorBoundary>
+      <div className={styles.FormRow}>{children}</div>
+    </ErrorBoundary>
+  );
+};
+
+export default FormRow;

--- a/packages/cascara/src/ui/Form/modules/index.js
+++ b/packages/cascara/src/ui/Form/modules/index.js
@@ -1,0 +1,7 @@
+import FormRow from './FormRow';
+
+const formModules = {
+  row: FormRow,
+};
+
+export { formModules };

--- a/packages/cascara/src/ui/Form/poc/FormPublicAPI.fixture.js
+++ b/packages/cascara/src/ui/Form/poc/FormPublicAPI.fixture.js
@@ -3,6 +3,8 @@ import React from 'react';
 import faker from 'faker';
 import JsonPlaceholder from '../../../placeholders/JsonPlaceholder';
 
+import Form from '../Form';
+
 // zero is not a valid seed for faker
 faker.seed(1);
 const data = {
@@ -21,139 +23,65 @@ const data = {
 const dataConfig = {
   actions: [
     {
-      label: 'Cancel',
-      module: 'button',
-    },
-    {
-      label: 'Save',
-      module: 'button',
-      variant: 'positive',
+      module: 'edit',
     },
   ],
   display: [
-    [
-      {
-        attribute: 'firstName',
-        label: 'First Name',
-        type: 'string',
-      },
-      {
-        attribute: 'lastName',
-        label: 'Last Name',
-        type: 'string',
-      },
-      {
-        attribute: 'lastName',
-        label: 'Last Name',
-        type: 'string',
-      },
-    ],
+    {
+      attribute: 'eid',
+      label: 'EID',
+      module: 'text',
+    },
+    {
+      fields: [
+        {
+          attribute: 'firstName',
+          label: 'First Name',
+          module: 'text',
+        },
+        {
+          attribute: 'lastName',
+          label: 'Last Name',
+          module: 'text',
+        },
+      ],
+      module: 'row',
+    },
     {
       attribute: 'homePhone',
       label: 'Home Phone',
-      type: 'phone',
+      module: 'text',
     },
-    [
-      {
-        attribute: 'title',
-        isEditable: false,
-        label: 'Title',
-        type: 'string',
-      },
-      {
-        attribute: 'department',
-        isEditable: false,
-        label: 'Department',
-        type: 'string',
-      },
-    ],
+    {
+      fields: [
+        {
+          attribute: 'title',
+          isEditable: false,
+          label: 'Title',
+          module: 'text',
+        },
+        {
+          attribute: 'department',
+          isEditable: false,
+          label: 'Department',
+          module: 'text',
+        },
+        {
+          attribute: 'country',
+          isEditable: false,
+          label: 'Country',
+          module: 'text',
+        },
+      ],
+      module: 'row',
+    },
   ],
-};
-
-const getValue = (data, config) => {
-  return { ...config, defaultValue: data[config.attribute] };
-};
-
-const prepareRowData = (data, rowConfig) =>
-  rowConfig.map((field) => getValue(data, field));
-
-// We will want to make this more robust to test multi-dimensional arrays and
-// then include it in the prepareFormData switch
-const isRow = (value) => {
-  switch (typeof value[0]) {
-    case 'undefined':
-      return false;
-    case 'object':
-      return true;
-    default:
-      throw new Error('Bad data but we do not know why right now');
-  }
-};
-
-const prepareFormData = (data, config) => {
-  const fields = config.display.map((field) => {
-    switch (typeof field[0]) {
-      // This case is actually for an object at the root of the array
-      case 'undefined':
-        return getValue(data, field);
-      // This case is technically telling us we have an object at the first index
-      // which means we have a multi-dimensional array.
-      case 'object':
-        return prepareRowData(data, field);
-      default:
-        throw new Error('Only objects or arrays are supported in data.display');
-    }
-  });
-
-  const actions = dataConfig.actions;
-
-  return {
-    actions,
-    fields,
-  };
 };
 
 const jsonStyle = {
   display: 'inline-block',
   verticalAlign: 'top',
   width: '50%',
-};
-
-const fakeFormStyle = {
-  display: 'inline-block',
-  verticalAlign: 'top',
-  width: '50%',
-};
-
-const Field = ({
-  label = 'label',
-  defaultValue = 'defaultValue',
-  isEditable = true,
-}) => {
-  const fakeContainer = {
-    margin: '1em',
-  };
-  const fakeInput = {
-    borderColor: isEditable ? 'grey' : 'transparent',
-    borderRadius: '.25em',
-    borderStyle: 'solid',
-    borderWidth: '1px',
-    padding: isEditable ? '.5em' : 0,
-  };
-  return (
-    <div style={fakeContainer}>
-      {label}
-      <div style={fakeInput}>{defaultValue}</div>
-    </div>
-  );
-};
-
-const FieldGroup = ({ children, length = 1 }) => {
-  const style = {
-    display: 'grid',
-    gridTemplateColumns: `repeat(${length}, 1fr)`,
-  };
-  return <div style={style}>{children}</div>;
 };
 
 const FormPublicAPI = ({ data, dataConfig }) => {
@@ -163,47 +91,10 @@ const FormPublicAPI = ({ data, dataConfig }) => {
         <h1>FormPublicAPI Test</h1>
       </div>
 
-      <JsonPlaceholder
-        data={data}
-        isInitialOpen
-        style={jsonStyle}
-        title='data'
-      />
-      <JsonPlaceholder
-        data={dataConfig}
-        isInitialOpen
-        style={jsonStyle}
-        title='dataConfig'
-      />
-      <JsonPlaceholder
-        data={prepareFormData(data, dataConfig)}
-        isInitialOpen
-        style={jsonStyle}
-        title='To Display'
-      />
-      <div style={fakeFormStyle}>
-        <div style={{ margin: '1em' }}>
-          <h2>Fake Form</h2>
-        </div>
-        {prepareFormData(data, dataConfig).fields.map((field, i) => {
-          if (isRow(field)) {
-            return (
-              <FieldGroup length={field.length}>
-                {field.map((rowField, i) => (
-                  <Field key={i} {...rowField} />
-                ))}
-              </FieldGroup>
-            );
-          } else {
-            return <Field key={i} {...field} />;
-          }
-        })}
-        <div style={{ margin: '1em', textAlign: 'right' }}>
-          {prepareFormData(data, dataConfig).actions.map((action, i) => (
-            <button key={i}>{action.label}</button>
-          ))}
-        </div>
-      </div>
+      <JsonPlaceholder data={data} style={jsonStyle} title='data' />
+      <JsonPlaceholder data={dataConfig} style={jsonStyle} title='dataConfig' />
+
+      <Form data={data} dataConfig={dataConfig} isInitialEditing />
     </div>
   );
 };

--- a/packages/cascara/src/ui/Form/poc/FormPublicAPI.fixture.js
+++ b/packages/cascara/src/ui/Form/poc/FormPublicAPI.fixture.js
@@ -44,8 +44,14 @@ const dataConfig = {
           label: 'Last Name',
           module: 'text',
         },
+        {
+          attribute: 'firstName',
+          label: 'First Name Again',
+          module: 'text',
+        },
       ],
       module: 'row',
+      ratio: [1, 1, 2],
     },
     {
       attribute: 'homePhone',

--- a/packages/cascara/src/ui/Table/Table.js
+++ b/packages/cascara/src/ui/Table/Table.js
@@ -35,7 +35,7 @@ const propTypes = {
         module: pt.oneOf(dataModuleOptions).isRequired,
       })
     ),
-  }),
+  }).isRequired,
 
   /** Event handler.
    *


### PR DESCRIPTION
## New Component Checklist

- [ ] Includes unit tests for _ALL_ required FDS use cases
- [ ] Does not mute any top level API props in React
- [x] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [ ] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node

## To Do
- [ ] Implement the action function for the form
- [ ] Set up the Form-specific FormActionEdit module