### PR TITLE
FDS-119 Focus styles to Stat Widget

### DIFF
--- a/packages/cascara/src/ui/Dashboard/Dashboard.module.scss
+++ b/packages/cascara/src/ui/Dashboard/Dashboard.module.scss
@@ -60,6 +60,7 @@ $widget-background: #f0f0f0;
   }
 
   .Stat {
+    position: relative;
     padding: 1em;
     background-color: $widget-background;
     border-radius: $widget-border-radius;
@@ -78,6 +79,24 @@ $widget-background: #f0f0f0;
     .Sub {
       font-style: italic;
       font-size: 0.875em;
+    }
+  }
+
+  .ClickableStat {
+    @extend .Stat;
+
+    position: relative;
+
+    &:after {
+      content: '⬁';
+      font-size: 1.2em;
+      position: absolute;
+      right: 1em;
+      opacity: 0.25;
+    }
+
+    &:focus:after {
+      opacity: 0.5;
     }
   }
 }

--- a/packages/cascara/src/ui/Dashboard/poc/DashboardPAC.fixture.js
+++ b/packages/cascara/src/ui/Dashboard/poc/DashboardPAC.fixture.js
@@ -13,6 +13,7 @@ import barDataDevice from '../data/BarDevice';
 const dataInteractions = [
   {
     label: 'Total Interactions',
+    onClick: () => alert('hi'),
     value: '12,535',
   },
   {
@@ -48,6 +49,11 @@ const dataDeflections = [
 
 const dashboardConfig = [
   {
+    actions: [
+      {
+        content: 'view',
+      },
+    ],
     data: dataInteractions,
     title: 'Interactions',
     widget: 'stats',

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetStats.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetStats.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import pt from 'prop-types';
-import { Clickable } from 'reakit';
 import Widget, { propTypes as widgetPT } from './Widget';
+import Stat from './WidgetStatsStat';
 import styles from '../Dashboard.module.scss';
 
 const propTypes = {
@@ -13,24 +13,15 @@ const propTypes = {
 /**
  * Widget for displaying stats
  */
-const WidgetStats = ({ data, ...rest }) => (
-  <Widget {...rest} className={styles.Stats} height='auto'>
-    {data?.map((stat) => (
-      <Clickable
-        as='div'
-        className={styles.Stat}
-        disabled={!Boolean(stat?.onClick)}
-        focusable={Boolean(stat?.onClick)}
-        key={stat.label}
-        onClick={stat?.onClick}
-      >
-        <span className={styles.Value}>{stat.value}</span>
-        <h4 className={styles.Label}>{stat.label}</h4>
-        {styles?.Sub && <span className={styles.Sub}>{stat.sub}</span>}
-      </Clickable>
-    ))}
-  </Widget>
-);
+const WidgetStats = ({ data, ...rest }) => {
+  return (
+    <Widget {...rest} className={styles.Stats} height='auto'>
+      {data?.map((stat) => (
+        <Stat {...stat} key={stat.label} />
+      ))}
+    </Widget>
+  );
+};
 
 WidgetStats.propTypes = propTypes;
 WidgetStats.displayName = 'stats';

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetStatsStat.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetStatsStat.js
@@ -1,0 +1,37 @@
+import React, { useCallback } from 'react';
+import { Clickable } from 'reakit';
+import styles from '../Dashboard.module.scss';
+
+const WidgetStatsStat = ({ onClick, label, value, sub }) => {
+  // Instead of maintaining separate, competing styles for focus, we are setting focus on this clickable item on hover. This may be something we consider doing on other Clickable components with Reakit.
+  const handleFocus = useCallback(({ currentTarget, dispatchConfig }) => {
+    const { registrationName } = dispatchConfig;
+
+    if (registrationName === 'onMouseEnter') {
+      currentTarget.focus();
+    } else if (registrationName === 'onMouseLeave') {
+      currentTarget.blur();
+    }
+  }, []);
+
+  return (
+    <Clickable
+      as='div'
+      className={Boolean(onClick) ? styles.ClickableStat : styles.Stat}
+      disabled={!Boolean(onClick)}
+      focusable={Boolean(onClick)}
+      key={label}
+      onClick={onClick}
+      onMouseEnter={handleFocus}
+      onMouseLeave={handleFocus}
+    >
+      <span className={styles.Value}>{value}</span>
+      <h4 className={styles.Label}>{label}</h4>
+      {sub && <span className={styles.Sub}>{sub}</span>}
+    </Clickable>
+  );
+};
+
+WidgetStatsStat.displayName = 'stats.stat';
+
+export default WidgetStatsStat;


### PR DESCRIPTION
## New Component Checklist

- [NA] Includes unit tests for _ALL_ required FDS use cases
- [x] Does not mute any top level API props in React
- [NA] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [x] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node

## This PR adds focus or blur to a stat if it is clickable/focusable. 

It also adds an icon to stat cards if they are clickable to make them more easily discoverable to users. No API changes needed for end users.

![image](https://user-images.githubusercontent.com/1161781/105546449-41096180-5cb2-11eb-97e8-2af715b62e87.png)
![image](https://user-images.githubusercontent.com/1161781/105546461-45357f00-5cb2-11eb-8add-b95c0ab4fe4d.png)
