### PR TITLE
FDS-136 Do not render popover as a modal

### DIFF
--- a/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
+++ b/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
@@ -30,7 +30,6 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
   });
 
   const menu = useMenuState({
-    modal: true,
     placement: 'bottom-end',
     unstable_popperModifiers: [popperOverTrigger],
   });

--- a/packages/cascara/src/ui/Popover/Popover.fixture.js
+++ b/packages/cascara/src/ui/Popover/Popover.fixture.js
@@ -32,6 +32,9 @@ const ActionsMenuFixture = (
       this menu.
     </p>
     <ActionsMenu actions={menuItems} />
+    <ActionsMenu actions={menuItems} />
+    <ActionsMenu actions={menuItems} />
+    <ActionsMenu actions={menuItems} />
   </main>
 );
 

--- a/packages/cascara/src/ui/Table/Table.test.snap
+++ b/packages/cascara/src/ui/Table/Table.test.snap
@@ -233,6 +233,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-2"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-2-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-2-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -401,6 +440,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-4"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-4-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-4-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -570,6 +648,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-6"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-6-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-6-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -739,6 +856,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-8"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-8-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-8-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -908,6 +1064,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-10"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-10-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-10-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -1076,6 +1271,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-12"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-12-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-12-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -1245,6 +1479,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-14"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-14-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-14-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -1414,6 +1687,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-16"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-16-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-16-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -1583,6 +1895,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-18"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-18-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-18-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -1751,6 +2102,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-20"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-20-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-20-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -1919,6 +2309,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-22"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-22-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-22-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -2088,6 +2517,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-24"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-24-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-24-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -2256,6 +2724,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-26"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-26-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-26-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -2425,6 +2932,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-28"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-28-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-28-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -2593,6 +3139,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-30"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-30-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-30-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -2762,6 +3347,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-32"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-32-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-32-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -2931,6 +3555,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-34"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-34-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-34-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -3100,6 +3763,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-36"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-36-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-36-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -3269,6 +3971,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-38"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-38-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-38-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -3438,6 +4179,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-40"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-40-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-40-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -3606,6 +4386,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-42"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-42-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-42-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -3774,6 +4593,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-44"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-44-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-44-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -3943,6 +4801,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-46"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-46-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-46-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -4112,6 +5009,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-48"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-48-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-48-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -4281,6 +5217,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-50"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-50-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-50-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -4450,6 +5425,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-52"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-52-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-52-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -4619,6 +5633,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-54"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-54-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-54-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -4788,6 +5841,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-56"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-56-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-56-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -4956,6 +6048,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-58"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-58-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-58-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -5124,6 +6255,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-60"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-60-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-60-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -5293,6 +6463,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-62"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-62-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-62-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -5461,6 +6670,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-64"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-64-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-64-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -5629,6 +6877,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-66"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-66-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-66-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -5798,6 +7085,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-68"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-68-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-68-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -5966,6 +7292,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-70"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-70-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-70-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -6135,6 +7500,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-72"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-72-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-72-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -6303,6 +7707,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-74"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-74-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-74-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -6472,6 +7915,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-76"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-76-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-76-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -6641,6 +8123,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-78"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-78-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-78-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -6809,6 +8330,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-80"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-80-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-80-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -6977,6 +8537,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-82"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-82-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-82-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -7146,6 +8745,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-84"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-84-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-84-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -7315,6 +8953,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-86"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-86-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-86-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -7483,6 +9160,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-88"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-88-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-88-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -7652,6 +9368,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-90"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-90-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-90-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -7821,6 +9576,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-92"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-92-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-92-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -7990,6 +9784,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-94"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-94-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-94-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -8159,6 +9992,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-96"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-96-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-96-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -8327,6 +10199,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-98"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-98-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-98-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -8495,6 +10406,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-100"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-100-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-100-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -8663,6 +10613,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-102"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-102-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-102-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -8831,6 +10820,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-104"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-104-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-104-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -9000,6 +11028,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-106"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-106-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-106-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -9168,6 +11235,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-108"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-108-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-108-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -9337,6 +11443,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-110"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-110-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-110-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -9505,6 +11650,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-112"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-112-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-112-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -9673,6 +11857,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-114"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-114-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-114-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -9841,6 +12064,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-116"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-116-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-116-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -10009,6 +12271,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-118"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-118-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-118-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -10177,6 +12478,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-120"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-120-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-120-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -10345,6 +12685,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-122"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-122-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-122-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -10513,6 +12892,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-124"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-124-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-124-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -10681,6 +13099,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-126"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-126-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-126-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -10850,6 +13307,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-128"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-128-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-128-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -11018,6 +13514,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-130"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-130-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-130-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -11186,6 +13721,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-132"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-132-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-132-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -11355,6 +13929,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-134"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-134-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-134-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -11523,6 +14136,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-136"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-136-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-136-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -11692,6 +14344,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-138"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-138-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-138-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -11861,6 +14552,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-140"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-140-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-140-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -12029,6 +14759,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-142"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-142-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-142-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -12198,6 +14967,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-144"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-144-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-144-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -12367,6 +15175,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-146"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-146-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-146-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -12536,6 +15383,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-148"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-148-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-148-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -12704,6 +15590,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-150"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-150-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-150-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -12873,6 +15798,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-152"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-152-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-152-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -13042,6 +16006,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-154"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-154-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-154-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -13211,6 +16214,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-156"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-156-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-156-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -13379,6 +16421,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-158"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-158-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-158-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -13548,6 +16629,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-160"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-160-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-160-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -13716,6 +16836,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-162"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-162-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-162-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -13885,6 +17044,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-164"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-164-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-164-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -14054,6 +17252,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-166"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-166-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-166-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -14222,6 +17459,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-168"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-168-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-168-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -14391,6 +17667,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-170"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-170-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-170-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -14559,6 +17874,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-172"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-172-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-172-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -14728,6 +18082,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-174"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-174-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-174-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -14897,6 +18290,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-176"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-176-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-176-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -15065,6 +18497,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-178"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-178-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-178-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -15233,6 +18704,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-180"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-180-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-180-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -15401,6 +18911,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-182"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-182-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-182-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -15570,6 +19119,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-184"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-184-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-184-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -15739,6 +19327,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-186"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-186-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-186-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -15908,6 +19535,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-188"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-188-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-188-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -16076,6 +19742,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-190"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-190-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-190-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -16245,6 +19950,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-192"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-192-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-192-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -16414,6 +20158,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-194"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-194-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-194-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -16583,6 +20366,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-196"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-196-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-196-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -16751,6 +20573,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-198"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-198-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-198-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
         <tr
@@ -16919,6 +20780,45 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
+            <div
+              aria-label="Menu"
+              aria-orientation="vertical"
+              class="ui dropdown active visible ActionsMenu"
+              data-dialog="true"
+              hidden=""
+              id="id-200"
+              role="menu"
+              style="display: none;"
+              tabindex="-1"
+            >
+              <div
+                class="menu transition visible"
+                style="position: initial;"
+              >
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="view"
+                  id="id-200-1"
+                  module="button"
+                  name="view"
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  view
+                </div>
+                <div
+                  class="item ActionsMenuItem"
+                  data-testid="delete"
+                  id="id-200-2"
+                  module="button"
+                  name="delete"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  delete
+                </div>
+              </div>
+            </div>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
We should now not have to worry about z-index from parent defined z-index and we will also not have a lot of extra portals sitting in the DOM.

This patch will need to be tested once published to verify.

### Snapshots
Updating Snapshot test due to the Menu no longer rendering in a portal, but instead now rendering adjacent to the menu button