### PR TITLE
FDS-137 - use action name for button name if no content is specified

### DIFF
--- a/packages/cascara/src/modules/ActionButton/ActionButton.js
+++ b/packages/cascara/src/modules/ActionButton/ActionButton.js
@@ -35,6 +35,9 @@ const ActionButton = ({
     and update our Apps we will revisit. */
   const name = actionName || rest.name;
 
+  // FDS-137: use action name for button name if no content is specified
+  const buttonText = content || name;
+
   const handleClick = ({ currentTarget }) => {
     onAction(currentTarget, record);
   };
@@ -47,7 +50,7 @@ const ActionButton = ({
       onClick={handleClick}
       type='button'
     >
-      {content}
+      {buttonText}
     </Button>
   );
 };

--- a/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
+++ b/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
@@ -56,19 +56,27 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
           className='menu transition visible'
           style={{ position: 'initial' }}
         >
-          {actions.map(({ content, isLabeled, ...rest }) => (
-            <MenuItem
-              {...menu}
-              {...rest}
-              as='div'
-              className={'item ' + styles.ActionsMenuItem}
-              key={content}
-              onClick={() => handleMenuItemClick(rest)}
-              style={{ paddingTop: '.5rem !important' }}
-            >
-              {content}
-            </MenuItem>
-          ))}
+          {actions.map(({ content, isLabeled, ...rest }, actionIndex) => {
+            // FDS-137: use action name for button name if no content is specified
+            const buttonText = content || rest.name;
+            const key = `action.${actionIndex}-${rest.name}.${content}`;
+
+            return (
+              <MenuItem
+                {...menu}
+                {...rest}
+                as='div'
+                className={'item ' + styles.ActionsMenuItem}
+                key={key}
+                onClick={() => handleMenuItemClick(rest)}
+                style={{
+                  paddingTop: '.5rem !important',
+                }}
+              >
+                {buttonText}
+              </MenuItem>
+            );
+          })}
         </div>
       </Menu>
     </>

--- a/packages/cascara/src/ui/Button/Button.js
+++ b/packages/cascara/src/ui/Button/Button.js
@@ -60,6 +60,9 @@ const Button = forwardRef(
       'ui button': true,
     });
 
+    // FDS-137: use action name for button name if no content is specified
+    const buttonText = content || rest.name;
+
     return (
       <ReakitButton
         {...rest}
@@ -68,7 +71,7 @@ const Button = forwardRef(
         ref={ref}
         rel={getSafeLinkRel(rest)}
       >
-        {content}
+        {buttonText}
       </ReakitButton>
     );
   }

--- a/packages/cascara/src/ui/Table/fixtures/ActionStack.Table..fixture.js
+++ b/packages/cascara/src/ui/Table/fixtures/ActionStack.Table..fixture.js
@@ -105,18 +105,17 @@ class Fixture extends PureComponent {
   render() {
     const { columns, data, display } = this.state;
     const dataConfig = {
-      actionButtonMenuIndex: 1,
+      actionButtonMenuIndex: 0,
       actions: [
         {
-          content: 'View interaction',
+          actionName: 'view',
           module: 'button',
-          name: 'view',
           size: 'small',
         },
         {
           content: 'View FAQ',
           module: 'button',
-          name: 'delete',
+          name: 'view.faq',
           size: 'small',
         },
         {


### PR DESCRIPTION
Hi team,

This PR adds the logic to use the action `name` if no `content` is specified.

## Snapshots
Snapshots are updated beccause the `content` || `name` changes reflected in DOM elements.