### PR TITLE
FDS-138 Return ActionsMenu to portal rendering, and set z-index

### DIFF
--- a/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
+++ b/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
@@ -1,5 +1,5 @@
 import pt from 'prop-types';
-import React, { useContext, useLayoutEffect, useRef } from 'react';
+import React, { useContext, useRef } from 'react';
 import { Menu, MenuButton, MenuItem, useMenuState } from 'reakit/Menu';
 import { Button } from 'reakit/Button';
 
@@ -23,14 +23,13 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
   // Set a ref on our trigger to pass into the disclosure and also measure clientHeight
   const triggerRef = useRef();
 
-  useLayoutEffect(() => {
-    if (triggerRef.current) {
-      // console.warn(window.getComputedStyle(triggerRef.current)['float']);
-    }
-  });
-
   const menu = useMenuState({
+    // This MUST be modal: true in order to render in a portal or else we
+    // will have problems with any menus rendered inside of positioned
+    // elements other than "relative"
+    modal: true,
     placement: 'bottom-end',
+    preventBodyScroll: true,
     unstable_popperModifiers: [popperOverTrigger],
   });
 
@@ -47,18 +46,18 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
       </MenuButton>
       <Menu
         {...menu}
-        aria-label='Menu'
+        aria-label='Actions Menu'
         className={'ui dropdown active visible ' + styles.ActionsMenu}
-        preventBodyScroll
+        tabIndex={0}
       >
         <div
           className='menu transition visible'
           style={{ position: 'initial' }}
         >
-          {actions.map(({ content, isLabeled, ...rest }, actionIndex) => {
+          {actions.map(({ content, isLabeled, name, ...rest }, actionIndex) => {
             // FDS-137: use action name for button name if no content is specified
-            const buttonText = content || rest.name;
-            const key = `action.${actionIndex}-${rest.name}.${content}`;
+            const buttonText = content || name;
+            const key = `action.${actionIndex}-${name}.${content}`;
 
             return (
               <MenuItem
@@ -68,9 +67,6 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
                 className={'item ' + styles.ActionsMenuItem}
                 key={key}
                 onClick={() => handleMenuItemClick(rest)}
-                style={{
-                  paddingTop: '.5rem !important',
-                }}
               >
                 {buttonText}
               </MenuItem>

--- a/packages/cascara/src/ui/ActionsMenu/ActionsMenu.module.scss
+++ b/packages/cascara/src/ui/ActionsMenu/ActionsMenu.module.scss
@@ -1,11 +1,5 @@
 .ActionsMenu {
-  // transition: opacity 250ms ease-in-out;
-  // opacity: 0;
-  // transform-origin: top center;
-
-  // &:global([data-enter]) {
-  //   opacity: 1;
-  // }
+  z-index: 11;
 
   &:global(.ui.dropdown) :global(.menu) {
     .ActionsMenuItem,

--- a/packages/cascara/src/ui/Table/Table.test.snap
+++ b/packages/cascara/src/ui/Table/Table.test.snap
@@ -233,45 +233,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-2"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-2-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-2-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -440,45 +401,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-4"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-4-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-4-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -648,45 +570,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-6"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-6-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-6-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -856,45 +739,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-8"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-8-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-8-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -1064,45 +908,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-10"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-10-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-10-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -1271,45 +1076,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-12"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-12-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-12-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -1479,45 +1245,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-14"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-14-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-14-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -1687,45 +1414,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-16"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-16-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-16-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -1895,45 +1583,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-18"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-18-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-18-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -2102,45 +1751,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-20"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-20-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-20-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -2309,45 +1919,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-22"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-22-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-22-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -2517,45 +2088,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-24"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-24-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-24-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -2724,45 +2256,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-26"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-26-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-26-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -2932,45 +2425,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-28"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-28-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-28-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -3139,45 +2593,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-30"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-30-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-30-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -3347,45 +2762,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-32"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-32-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-32-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -3555,45 +2931,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-34"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-34-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-34-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -3763,45 +3100,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-36"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-36-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-36-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -3971,45 +3269,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-38"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-38-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-38-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -4179,45 +3438,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-40"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-40-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-40-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -4386,45 +3606,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-42"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-42-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-42-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -4593,45 +3774,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-44"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-44-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-44-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -4801,45 +3943,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-46"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-46-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-46-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -5009,45 +4112,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-48"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-48-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-48-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -5217,45 +4281,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-50"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-50-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-50-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -5425,45 +4450,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-52"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-52-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-52-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -5633,45 +4619,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-54"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-54-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-54-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -5841,45 +4788,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-56"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-56-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-56-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -6048,45 +4956,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-58"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-58-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-58-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -6255,45 +5124,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-60"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-60-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-60-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -6463,45 +5293,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-62"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-62-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-62-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -6670,45 +5461,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-64"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-64-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-64-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -6877,45 +5629,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-66"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-66-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-66-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -7085,45 +5798,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-68"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-68-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-68-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -7292,45 +5966,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-70"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-70-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-70-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -7500,45 +6135,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-72"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-72-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-72-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -7707,45 +6303,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-74"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-74-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-74-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -7915,45 +6472,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-76"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-76-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-76-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -8123,45 +6641,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-78"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-78-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-78-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -8330,45 +6809,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-80"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-80-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-80-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -8537,45 +6977,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-82"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-82-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-82-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -8745,45 +7146,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-84"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-84-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-84-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -8953,45 +7315,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-86"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-86-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-86-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -9160,45 +7483,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-88"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-88-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-88-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -9368,45 +7652,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-90"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-90-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-90-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -9576,45 +7821,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-92"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-92-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-92-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -9784,45 +7990,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-94"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-94-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-94-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -9992,45 +8159,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-96"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-96-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-96-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -10199,45 +8327,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-98"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-98-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-98-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -10406,45 +8495,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-100"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-100-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-100-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -10613,45 +8663,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-102"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-102-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-102-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -10820,45 +8831,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-104"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-104-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-104-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -11028,45 +9000,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-106"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-106-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-106-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -11235,45 +9168,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-108"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-108-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-108-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -11443,45 +9337,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-110"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-110-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-110-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -11650,45 +9505,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-112"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-112-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-112-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -11857,45 +9673,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-114"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-114-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-114-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -12064,45 +9841,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-116"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-116-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-116-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -12271,45 +10009,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-118"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-118-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-118-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -12478,45 +10177,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-120"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-120-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-120-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -12685,45 +10345,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-122"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-122-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-122-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -12892,45 +10513,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-124"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-124-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-124-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -13099,45 +10681,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-126"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-126-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-126-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -13307,45 +10850,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-128"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-128-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-128-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -13514,45 +11018,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-130"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-130-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-130-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -13721,45 +11186,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-132"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-132-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-132-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -13929,45 +11355,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-134"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-134-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-134-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -14136,45 +11523,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-136"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-136-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-136-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -14344,45 +11692,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-138"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-138-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-138-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -14552,45 +11861,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-140"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-140-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-140-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -14759,45 +12029,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-142"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-142-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-142-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -14967,45 +12198,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-144"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-144-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-144-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -15175,45 +12367,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-146"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-146-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-146-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -15383,45 +12536,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-148"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-148-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-148-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -15590,45 +12704,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-150"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-150-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-150-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -15798,45 +12873,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-152"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-152-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-152-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -16006,45 +13042,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-154"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-154-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-154-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -16214,45 +13211,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-156"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-156-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-156-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -16421,45 +13379,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-158"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-158-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-158-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -16629,45 +13548,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-160"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-160-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-160-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -16836,45 +13716,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-162"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-162-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-162-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -17044,45 +13885,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-164"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-164-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-164-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -17252,45 +14054,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-166"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-166-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-166-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -17459,45 +14222,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-168"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-168-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-168-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -17667,45 +14391,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-170"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-170-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-170-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -17874,45 +14559,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-172"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-172-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-172-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -18082,45 +14728,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-174"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-174-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-174-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -18290,45 +14897,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-176"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-176-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-176-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -18497,45 +15065,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-178"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-178-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-178-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -18704,45 +15233,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-180"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-180-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-180-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -18911,45 +15401,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-182"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-182-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-182-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -19119,45 +15570,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-184"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-184-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-184-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -19327,45 +15739,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-186"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-186-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-186-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -19535,45 +15908,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-188"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-188-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-188-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -19742,45 +16076,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-190"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-190-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-190-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -19950,45 +16245,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-192"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-192-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-192-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -20158,45 +16414,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-194"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-194-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-194-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -20366,45 +16583,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-196"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-196-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-196-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -20573,45 +16751,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-198"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-198-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-198-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
         <tr
@@ -20780,45 +16919,6 @@ exports[`Table component tree snapshot test 1`] = `
                 ⋯
               </b>
             </button>
-            <div
-              aria-label="Menu"
-              aria-orientation="vertical"
-              class="ui dropdown active visible ActionsMenu"
-              data-dialog="true"
-              hidden=""
-              id="id-200"
-              role="menu"
-              style="display: none;"
-              tabindex="-1"
-            >
-              <div
-                class="menu transition visible"
-                style="position: initial;"
-              >
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="view"
-                  id="id-200-1"
-                  module="button"
-                  name="view"
-                  role="menuitem"
-                  tabindex="0"
-                >
-                  view
-                </div>
-                <div
-                  class="item ActionsMenuItem"
-                  data-testid="delete"
-                  id="id-200-2"
-                  module="button"
-                  name="delete"
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  delete
-                </div>
-              </div>
-            </div>
           </td>
         </tr>
       </tbody>

--- a/packages/cascara/src/ui/Table/fixtures/ActionStack.Table.fixture.js
+++ b/packages/cascara/src/ui/Table/fixtures/ActionStack.Table.fixture.js
@@ -108,21 +108,26 @@ class Fixture extends PureComponent {
       actionButtonMenuIndex: 0,
       actions: [
         {
-          actionName: 'view',
           module: 'button',
-          size: 'small',
+          name: 'test',
+        },
+        {
+          module: 'button',
+          name: 'stuff',
+        },
+        {
+          module: 'button',
+          name: 'okay',
         },
         {
           content: 'View FAQ',
           module: 'button',
           name: 'view.faq',
-          size: 'small',
         },
         {
           content: 'edit',
           module: 'edit',
           name: 'edit',
-          size: 'small',
         },
       ],
       display,


### PR DESCRIPTION
### Snapshots

Snapshot tests are being updated here because the menu is no longer being rendered inline. There would technically be no way to break out of the positioning here with the popper due to the sticky cell position.

Note that these snapshot tests are not actually showing the menu as it is being rendered in a portal. Something for us to think about in the future.