### PR TITLE
fix(ActionsMenu): not passing 'name' prop down to the DOM element

### DIFF
--- a/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
+++ b/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
@@ -54,24 +54,26 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
           className='menu transition visible'
           style={{ position: 'initial' }}
         >
-          {actions.map(({ content, isLabeled, name, ...rest }, actionIndex) => {
-            // FDS-137: use action name for button name if no content is specified
-            const buttonText = content || name;
-            const key = `action.${actionIndex}-${name}.${content}`;
+          {actions.map(
+            ({ actionName, content, isLabeled, ...rest }, actionIndex) => {
+              // FDS-137: use action name for button name if no content is specified
+              const buttonText = content || rest.name;
+              const key = `action.${actionIndex}-${rest.name}.${content}`;
 
-            return (
-              <MenuItem
-                {...menu}
-                {...rest}
-                as='div'
-                className={'item ' + styles.ActionsMenuItem}
-                key={key}
-                onClick={() => handleMenuItemClick(rest)}
-              >
-                {buttonText}
-              </MenuItem>
-            );
-          })}
+              return (
+                <MenuItem
+                  {...menu}
+                  {...rest}
+                  as='div'
+                  className={'item ' + styles.ActionsMenuItem}
+                  key={key}
+                  onClick={() => handleMenuItemClick(rest)}
+                >
+                  {buttonText}
+                </MenuItem>
+              );
+            }
+          )}
         </div>
       </Menu>
     </>


### PR DESCRIPTION
## FDS-140

### Bug: <ActionsMenu /> not passing 'name' prop down to the DOM element.

This ends up breaking the `onAction` handler logic that relies on the DOM element having a `name` attribute.

### Fix: 

- `name` is now kept in `...rest` so it reaches the DOM.
- `actionName` is defensively mutted before rendering the menu item

- [x] Includes unit tests for _ALL_ required FDS use cases
- [x] Does not mute any top level API props in React
- [x] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [x] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node
