### PR TITLE
feat(Table): Conditional actions

### DIFF
--- a/packages/cascara/src/lib/mock/fakeData.js
+++ b/packages/cascara/src/lib/mock/fakeData.js
@@ -43,6 +43,7 @@ export const generateFakeInteractions = (qty) =>
       matchedIntent,
       phrase: faker.lorem.sentence(5),
       response: faker.random.boolean(),
+      type: faker.random.arrayElement(['faq', 'other', 'interaction']),
       user: `${firstName} ${lastName}`,
     });
   });

--- a/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
+++ b/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
@@ -36,7 +36,9 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
   const handleMenuItemClick = (item) => {
     menu.hide();
 
-    onAction(item, record);
+    if (onAction) {
+      onAction(item, record);
+    }
   };
 
   return (

--- a/packages/cascara/src/ui/Table/0-Table.mdx
+++ b/packages/cascara/src/ui/Table/0-Table.mdx
@@ -38,35 +38,47 @@ const data = {[
 ]}
 ```
 
-## dataConfig
-
-Here you can specify the columns to display as well as the available actions (if any) for each row.
-This is the core of Table's configuration, here you can define:
-
-### actions
+## actions
 
 Actions represent 'verbs' we want to apply to our Table rows, like 'view' to navigate to another page with detailed information about the row.
 Another example would be 'Delete' to delete a row. 'actions' will be appended to each row, they'll appear as buttons.
+By defining an 'action', you are telling Table how you want to be notified when your 'action' button is pressed. Via the 'onAction' event.
 
 > Table does not provide the logic to handle 'actions', the implementation for deleting a row, navigating to another page, etc. it's up to you.
 
-By defining an 'action', you are telling Table how you want to be notified when your 'action' button is pressed. Via the 'onAction' event.
+The shape of `actions` is as follows:
 
-```javascript
----
-title: The shape of an action
----
-const action = {
-  module: 'button', // either button or edit
-  name: 'view', // the action name
-  content: 'View', // button text
-  size: 'small',  // button size
-},
+```javasccript
+const actions = {
+  actionButtonMenuIndex: 0,
+  modules: [
+   {
+      module: 'button',
+      name: 'view',
+      content: 'view',
+    },
+    {
+      module: 'edit',
+      cancelLabel: 'Cancelar',
+      editLabel: 'Editar',
+      saveLabel: 'Guardar',
+    },
+  ],
+  resolveRecordActions: (record, actions) => (actionsForRecord),
+}
 ```
 
-#### Action modules
+### actionButtonMenuIndex
 
-At the moment, we have only two types of modules.
+Tables can become bloated if you use lots of actions, in order to prevent this, the actions are wrapped by an `ActionsMenu`, a contextual menu accessible via the `meatball` button of each row.
+
+You can specify which actions are sent to the `ActionsMenu` using the `actionButtonMenuIndex` prop, a number that acts like a partition index that will take your actions array and slice it. The actions whose index is greater or equal to `actionButtonMenuIndex` will be part of `ActionsMenu`, the rest will be displayed as usual.
+
+> This only applies to `button` actions, `edit` actions will always be displayed as usual.
+
+### modules
+
+At the moment, we have only two types of action modules.
 
 - `button`, for simple actions like deleting a row, navigating to another page, etc.
 - `edit`, to be used if you want to allow the data to be `editable`.
@@ -80,43 +92,41 @@ In the case of `edit`, the `onAction` event will be emitted up to 3 times as it 
 
 All this information is part of the `onAction` event signature, please make sure you review it as well.
 
-An example set of actions:
+### resolveRecordActions
 
-```javascript
----
-title: An example set of actions
----
+A function that returns the actions available to the current row.
 
-const actions: [
+```javasccript
+resolveRecordActions(record, actions) {
+  return actions.reduce((actionsForRecord, action) => {
+    switch (action.name) {
+      case 'edit':
+        // do not show if record is deflected
+        if (!record.deflected) {
+          actionsForRecord.push(action);
+        }
+        break;
 
-  // simple button
-  {
-    module: 'button',
-    name: 'view',
-    content: 'view',
-    size: 'small',
-  },
+      case 'view.faq':
+        // do not show view button for FAQs
+        if (record.type !== 'faq') {
+          actionsForRecord.push(action);
+        }
+        break;
 
-  // or
+      default:
+        actionsForRecord.push(action);
+    }
 
-  // edit button combo (for editable rows)
-  {
-    module: 'edit',
-    size: 'small',
-    cancelLabel: 'Cancelar', // you can specify localized labels
-    editLabel: 'Editar',
-    saveLabel: 'Guardar',
-  },
-];
+    return actionsForRecord;
+  }, []);
+};
 ```
 
-### actionButtonMenuIndex
+## dataConfig
 
-Tables can become bloated if you use lots of actions, in order to prevent this, the actions are wrapped by an `ActionsMenu`, a contextual menu accessible via the `meatball` button of each row.
-
-You can specify which actions are sent to the `ActionsMenu` using the `actionButtonMenuIndex` prop, a number that acts like a partition index that will take your actions array and slice it. The actions whose index is greater or equal to `actionButtonMenuIndex` will be part of `ActionsMenu`, the rest will be displayed as usual.
-
-> This only applies to `button` actions, `edit` actions will always be displayed as usual.
+Here you can specify the columns to display as well as the available actions (if any) for each row.
+This is the core of Table's configuration, here you can define:
 
 ### display
 

--- a/packages/cascara/src/ui/Table/Table.js
+++ b/packages/cascara/src/ui/Table/Table.js
@@ -43,6 +43,10 @@ const propTypes = {
    * An event handler you can pass to handle every event your table emits.*/
   onAction: pt.func,
 
+  /** Resolve record actions.
+   * A function that returns the actions available to the current row */
+  resolveRecordActions: pt.func,
+
   /** Unique ID Attribute.
    *
    * specifies the attribute that uniquely identifies every object in the 'data' array. */
@@ -54,6 +58,7 @@ const Table = ({
   data = [],
   dataConfig = {},
   onAction = (type, data) => type,
+  resolveRecordActions,
   uniqueIdAttribute,
   ...rest
 }) => {
@@ -71,6 +76,7 @@ const Table = ({
           data,
           dataConfig,
           onAction,
+          resolveRecordActions,
           uniqueIdAttribute,
         }}
         {...rest}

--- a/packages/cascara/src/ui/Table/Table.js
+++ b/packages/cascara/src/ui/Table/Table.js
@@ -14,6 +14,21 @@ const actionModuleOptions = Object.keys(actionModules);
 const dataModuleOptions = Object.keys(dataModules);
 
 const propTypes = {
+  /** Actions will be appended to each row, they'll appear as buttons. */
+  actions: pt.shape({
+    actionButtonMenuIndex: pt.number,
+
+    modules: pt.arrayOf(
+      pt.shape({
+        module: pt.oneOf(actionModuleOptions).isRequired,
+      })
+    ),
+
+    /** Resolve record actions.
+     * A function that returns the actions available to the current row */
+    resolveRecordActions: pt.func,
+  }),
+
   /** An array of objects.
    *
    * Every object in this array will potencially be rendered as a table row. */
@@ -23,6 +38,7 @@ const propTypes = {
    * as well as the available actions (if any) for each row. */
   dataConfig: pt.shape({
     actionButtonMenuIndex: pt.number,
+
     /** Actions will be appended to each row, they'll appear as buttons. */
     actions: pt.arrayOf(
       pt.shape({
@@ -55,17 +71,42 @@ const propTypes = {
 
 /** This is a Table */
 const Table = ({
-  data = [],
-  dataConfig = {},
-  onAction = (type, data) => type,
-  resolveRecordActions,
+  actions,
+  data,
+  dataConfig,
+  onAction,
   uniqueIdAttribute,
   ...rest
 }) => {
-  const { actions = [], display = [] } = dataConfig;
+  const display = dataConfig?.display;
+
+  // // FDS-142: new action props
+  let actionButtonMenuIndex = actions?.actionButtonMenuIndex;
+  let modules = actions?.modules;
+  let resolveRecordActions = actions?.resolveRecordActions;
+
+  // old action props
+  const unwantedActions = dataConfig?.actions;
+  if (unwantedActions) {
+    modules = unwantedActions;
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Prop "dataConfig.actions" has been deprecated. Actions have been moved to the root of the Table component as their own prop.'
+    );
+  }
+
+  const unwantedActionButtonIndex = dataConfig?.actionButtonIndex;
+  if (unwantedActionButtonIndex) {
+    actionButtonMenuIndex = unwantedActionButtonIndex;
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Prop "dataConfig.actionButtonIndex" has been deprecated. Actions have been moved to the root of the Table component as their own prop.'
+    );
+  }
+
   let columnCount = display.length;
 
-  if (actions.length) {
+  if (modules.length) {
     columnCount++;
   }
 
@@ -73,8 +114,10 @@ const Table = ({
     <ErrorBoundary>
       <TableProvider
         value={{
+          actionButtonMenuIndex,
           data,
           dataConfig,
+          modules,
           onAction,
           resolveRecordActions,
           uniqueIdAttribute,

--- a/packages/cascara/src/ui/Table/TableRow.js
+++ b/packages/cascara/src/ui/Table/TableRow.js
@@ -35,21 +35,25 @@ const propTypes = {
 const TableRow = ({ config = {}, record = {} }) => {
   const { id, columns } = config;
   const {
+    resolveRecordActions,
     dataConfig: { actionButtonMenuIndex = 0, actions: userDefinedActions = [] },
   } = useContext(ModuleContext);
+
+  // If a resolver is passed, get actions from it
+  const actions = resolveRecordActions
+    ? resolveRecordActions(record, userDefinedActions)
+    : resolveRecordActions; // otherwise continue as normal
+
   const outsideButtonActions = [];
   const insideButtonActions = [];
-  userDefinedActions
+  actions
     .filter(({ module }) => module === 'button')
     .map((action, index) =>
       index >= actionButtonMenuIndex
         ? insideButtonActions.push(action)
         : outsideButtonActions.push(action)
     );
-  const specialActions = userDefinedActions.filter(
-    ({ module }) => module !== 'button'
-  );
-
+  const specialActions = actions.filter(({ module }) => module !== 'button');
   const outsideActions = [...specialActions, ...outsideButtonActions];
 
   const renderActionModule = (action, index) => {
@@ -68,7 +72,7 @@ const TableRow = ({ config = {}, record = {} }) => {
     );
   };
 
-  const actions = (
+  const rowActions = (
     <td className={styles.CellActions} key={`${id}-actionbar`}>
       {outsideActions.map(renderActionModule)}
       {Boolean(insideButtonActions.length) ? (
@@ -94,7 +98,7 @@ const TableRow = ({ config = {}, record = {} }) => {
   });
 
   if (userDefinedActions.length) {
-    rowCells.push(actions);
+    rowCells.push(rowActions);
   }
 
   return (

--- a/packages/cascara/src/ui/Table/TableRow.js
+++ b/packages/cascara/src/ui/Table/TableRow.js
@@ -36,13 +36,14 @@ const TableRow = ({ config = {}, record = {} }) => {
   const { id, columns } = config;
   const {
     resolveRecordActions,
-    dataConfig: { actionButtonMenuIndex = 0, actions: userDefinedActions = [] },
+    actionButtonMenuIndex = 0,
+    modules: userDefinedModules = [],
   } = useContext(ModuleContext);
 
-  // If a resolver is passed, get actions from it
+  // FDS-142: If a resolver is passed, get actions from it
   const actions = resolveRecordActions
-    ? resolveRecordActions(record, userDefinedActions)
-    : resolveRecordActions; // otherwise continue as normal
+    ? resolveRecordActions(record, userDefinedModules)
+    : userDefinedModules; // otherwise continue as normal
 
   const outsideButtonActions = [];
   const insideButtonActions = [];
@@ -97,7 +98,7 @@ const TableRow = ({ config = {}, record = {} }) => {
     );
   });
 
-  if (userDefinedActions.length) {
+  if (userDefinedModules.length) {
     rowCells.push(rowActions);
   }
 

--- a/packages/cascara/src/ui/Table/fixtures/Conditional.Actions.fixture.js
+++ b/packages/cascara/src/ui/Table/fixtures/Conditional.Actions.fixture.js
@@ -1,0 +1,222 @@
+import React, { PureComponent } from 'react';
+import { Dropdown, Header } from 'semantic-ui-react';
+
+import JsonPlaceholder from '../../../placeholders/JsonPlaceholder';
+
+import { generateFakeInteractions } from '../../../lib/mock/fakeData';
+import Table from '..';
+
+const defaultColumns = [
+  {
+    attribute: 'created',
+    isEditable: true,
+    isLabeled: false,
+    label: 'Created',
+    module: 'text',
+  },
+  {
+    attribute: 'phrase',
+    isEditable: false,
+    isLabeled: false,
+    label: 'Phrase',
+    module: 'text',
+  },
+  {
+    attribute: 'user',
+    isEditable: true,
+    isLabeled: false,
+    label: 'User',
+    module: 'email',
+  },
+  {
+    attribute: 'response',
+    isEditable: true,
+    isLabeled: false,
+    label: 'Response',
+    module: 'checkbox',
+  },
+  {
+    attribute: 'deflected',
+    isEditable: true,
+    isLabeled: false,
+    label: 'Deflected',
+    module: 'checkbox',
+  },
+  {
+    attribute: 'matchedIntent',
+    isEditable: true,
+    isLabeled: false,
+    label: 'Matched Intent',
+    module: 'text',
+  },
+
+  {
+    attribute: 'type',
+    isEditable: true,
+    isLabeled: false,
+    label: 'Type',
+    module: 'text',
+  },
+];
+
+class Fixture extends PureComponent {
+  state = {
+    columns: [...defaultColumns],
+    data: generateFakeInteractions(50).map((interaction) => ({
+      ...interaction,
+    })),
+    display: [...defaultColumns],
+  };
+
+  handleColumnSelection = (_, { value: selectedColumns }) => {
+    const { columns } = this.state;
+    const newDisplay = columns
+      .filter((column) => selectedColumns.includes(column.attribute))
+      .reverse();
+
+    this.setState({ display: newDisplay });
+  };
+
+  handleRecordUpdate = (record) => {
+    const { data } = this.state;
+
+    const updatedData = data.map((recordInState) => {
+      if (recordInState.eid !== record.eid) {
+        return recordInState;
+      }
+
+      return {
+        ...recordInState,
+        ...record,
+      };
+    });
+
+    this.setState({ data: updatedData });
+  };
+
+  handleTableAction = (caller, data) => {
+    // eslint-ignore-next-line no-console
+    console.log(`Action: '${caller.name}' has been invoked:`);
+    // eslint-ignore-next-line no-console
+    console.table(data);
+
+    switch (caller.name) {
+      case 'edit.save':
+        this.handleRecordUpdate(data);
+        break;
+
+      default:
+        return;
+    }
+  };
+
+  resolveRecordActions(record, actions) {
+    return actions.reduce((actionsForRecord, action) => {
+      switch (action.name) {
+        /**
+         * Idealy, Cascara actions would always go first
+         * because they go outside the ActionsMenu.
+         *
+         * Since that is something we cannot control, we
+         * will have to filter them out inside Cascara. */
+        case 'edit':
+          // do not show if record is deflected
+          if (!record.deflected) {
+            actionsForRecord.push(action);
+          }
+          break;
+
+        case 'view.faq':
+          // do not show view button for FAQs
+          if (record.type !== 'faq') {
+            actionsForRecord.push(action);
+          }
+          break;
+
+        default:
+          actionsForRecord.push(action);
+      }
+
+      return actionsForRecord;
+    }, []);
+  }
+
+  render() {
+    const { columns, data, display } = this.state;
+    const dataConfig = {
+      actionButtonMenuIndex: 0,
+      actions: [
+        {
+          content: 'test',
+          module: 'button',
+          name: 'test',
+        },
+        {
+          content: 'stuff',
+          module: 'button',
+          name: 'stuff',
+        },
+        {
+          content: 'okay',
+          module: 'button',
+          name: 'okay',
+        },
+        {
+          content: 'View FAQ',
+          module: 'button',
+          name: 'view.faq',
+        },
+        {
+          module: 'edit',
+          name: 'edit',
+        },
+      ],
+      display,
+    };
+
+    const availableColumns = columns.map((columnDef) => ({
+      key: columnDef.attribute,
+      text: columnDef.content,
+      value: columnDef.attribute,
+    }));
+
+    const selectedColumns = display.map((columnDef) => columnDef.attribute);
+
+    return (
+      <>
+        <JsonPlaceholder data={dataConfig} title='dataConfig' />
+        <JsonPlaceholder
+          data={{ availableColumns, selectedColumns }}
+          title='available vs. selected columns'
+        />
+        <Header as='h4'>
+          <Header.Content>
+            Displaying columns: <br />
+            <Dropdown
+              header='Select columns...'
+              key={'select'}
+              labeled
+              multiple
+              onChange={this.handleColumnSelection}
+              options={availableColumns}
+              placeholder='select columns...'
+              selectedLabel={'Display columns'}
+              selection
+              value={selectedColumns}
+            />
+          </Header.Content>
+        </Header>
+
+        <Table
+          data={data}
+          dataConfig={dataConfig}
+          onAction={this.handleTableAction}
+          resolveRecordActions={this.resolveRecordActions}
+          uniqueIdAttribute={'eid'}
+        />
+      </>
+    );
+  }
+}
+
+export default Fixture;


### PR DESCRIPTION
Hi team,

This is a PoC on how we could handle `conditional actions` for Table.

This would add to Table:

- an `opt-in` prop `resolveRecordActions`. A function that receives 1) the current record and 2) the list of actions defined for the table; and returns the set of actions for that specific record.
- the minimal changes to make this work without making breaking changes

## How to test

1. `yarn cosmos`
2. visit `Conditional actions` fixture
