### PR TITLE
chore(FDS-153) - Fix remaining eslint rule errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,17 +12,4 @@ module.exports = {
     },
   ],
   root: true,
-  rules: {
-    // TODO: Remove each of these lines below until there are 10 files with errors and resolve with --fix or manually, then submit a PR and repeat
-    'consistent-return': 0,
-    'eslint-comments/disable-enable-pair': 0,
-    'eslint-comments/no-unused-disable': 0,
-    'eslint-comments/require-description': 0,
-    'jest/no-done-callback': 0,
-    'react/jsx-key': 0,
-    'react/jsx-no-bind': 0,
-    'react/no-unknown-property': 0,
-    'sort-imports': 0,
-    'sort-keys': 0,
-  },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,19 +1,4 @@
 module.exports = {
-  presets: [
-    [
-      '@babel/preset-env',
-      {
-        modules: false,
-        loose: true,
-      },
-    ],
-    '@babel/preset-react',
-  ],
-  plugins: [
-    '@babel/plugin-proposal-export-default-from',
-    '@babel/plugin-proposal-optional-chaining',
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-  ],
   env: {
     // Jest
     test: {
@@ -23,4 +8,24 @@ module.exports = {
       ],
     },
   },
+  plugins: [
+    '@babel/plugin-proposal-export-default-from',
+    '@babel/plugin-proposal-optional-chaining',
+    [
+      '@babel/plugin-proposal-class-properties',
+      {
+        loose: true,
+      },
+    ],
+  ],
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        loose: true,
+        modules: false,
+      },
+    ],
+    '@babel/preset-react',
+  ],
 };

--- a/docs/src/components/Code/Code.js
+++ b/docs/src/components/Code/Code.js
@@ -25,16 +25,16 @@ const Code = ({ children, className, live = true, title, ...rest }) => {
 
   const [editorCode, setEditorCode] = useState(children.trim());
 
-  const handleEditorToggle = () => {
+  function handleEditorToggle() {
     // TODO: Make cursor focus on editor when opening
     // should also update styles for focus on editor so it is easier to see that it
     // is actually editable
     setEditorOpen(!editorOpen);
-  };
+  }
 
-  const handleCodeChange = (code) => {
+  function handleCodeChange(code) {
     setEditorCode(code.trim());
-  };
+  }
 
   useEffect(() => {
     setEditorCode(children.trim());

--- a/docs/src/components/Code/Code.js
+++ b/docs/src/components/Code/Code.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live';
 import theme from 'prism-react-renderer/themes/synthwave84';
 import pt from 'prop-types';
@@ -25,16 +25,19 @@ const Code = ({ children, className, live = true, title, ...rest }) => {
 
   const [editorCode, setEditorCode] = useState(children.trim());
 
-  function handleEditorToggle() {
+  const handleEditorToggle = useCallback(() => {
     // TODO: Make cursor focus on editor when opening
     // should also update styles for focus on editor so it is easier to see that it
     // is actually editable
     setEditorOpen(!editorOpen);
-  }
+  }, [setEditorOpen, editorOpen]);
 
-  function handleCodeChange(code) {
-    setEditorCode(code.trim());
-  }
+  const handleCodeChange = useCallback(
+    (code) => {
+      setEditorCode(code.trim());
+    },
+    [setEditorCode]
+  );
 
   useEffect(() => {
     setEditorCode(children.trim());

--- a/docs/src/components/PropTable/PropTable.js
+++ b/docs/src/components/PropTable/PropTable.js
@@ -5,9 +5,9 @@ import styles from './PropTable.module.scss';
 
 const propTypes = {
   docData: pt.shape({
-    props: pt.shape({}),
-    displayName: pt.string,
     description: pt.string,
+    displayName: pt.string,
+    props: pt.shape({}),
   }),
 };
 

--- a/docs/src/lib/MDX_COMPONENTS.js
+++ b/docs/src/lib/MDX_COMPONENTS.js
@@ -29,7 +29,7 @@ import {
 
 import { Asciagram, Code, Placeholder } from '../components';
 
-/* eslint-disable react/display-name, react/no-multi-comp  -- We need to do this in order to get all of our components into MDX */
+/* eslint-disable eslint-comments/disable-enable-pair, react/display-name, react/no-multi-comp  -- We need to do this in order to get all of our components into MDX */
 const docsComponents = {
   Asciagram: (props) => <Asciagram {...props} />,
   Playground: (props) => <Placeholder {...props} componentName='Playground' />,

--- a/docs/src/lib/MDX_COMPONENTS.js
+++ b/docs/src/lib/MDX_COMPONENTS.js
@@ -29,7 +29,7 @@ import {
 
 import { Asciagram, Code, Placeholder } from '../components';
 
-/* eslint-disable eslint-comments/disable-enable-pair, react/display-name, react/no-multi-comp  -- We need to do this in order to get all of our components into MDX */
+/* eslint-disable react/display-name, react/no-multi-comp  -- We need to do this in order to get all of our components into MDX */
 const docsComponents = {
   Asciagram: (props) => <Asciagram {...props} />,
   Playground: (props) => <Placeholder {...props} componentName='Playground' />,
@@ -62,7 +62,7 @@ const privateComponents = {
   DataTextArea: (props) => <DataTextArea {...props} />,
   ModuleProvider: (props) => <ModuleProvider {...props} />,
 };
-/* eslint-enable react/no-multi-comp */
+/* eslint-enable react/display-name, react/no-multi-comp */
 
 const MDX_COMPONENTS = {
   ...cascaraComponents,

--- a/docs/src/pages/[slug].js
+++ b/docs/src/pages/[slug].js
@@ -2,15 +2,15 @@ import hydrate from 'next-mdx-remote/hydrate';
 import Head from 'next/head';
 import pt from 'prop-types';
 
-import { POSTS_PATH, postFilePaths } from '../lib/mdxUtils';
+import { postFilePaths, POSTS_PATH } from '../lib/mdxUtils';
 import getMDXTree from '../lib/getMDXTree';
 import MDX_COMPONENTS from '../lib/MDX_COMPONENTS';
 import MDX_OPTIONS from '../lib/MDX_OPTIONS';
 
 const propTypes = {
   frontMatter: pt.shape({
-    title: pt.string,
     description: pt.string,
+    title: pt.string,
   }),
   source: pt.string,
 };

--- a/docs/src/pages/_app.js
+++ b/docs/src/pages/_app.js
@@ -49,12 +49,14 @@ const MyApp = ({ Component, pageProps }) => {
           propTable?.length > 0 && (
             <Admin.Drawer>
               {propTable.map((componentProps) => (
-                <AnimatePresence exitBeforeEnter>
+                <AnimatePresence
+                  exitBeforeEnter
+                  key={router.query.mdx + componentProps}
+                >
                   <motion.div
                     animate={{ opacity: 1, translateX: 0 }}
                     exit={{ opacity: 0, translateX: 100 }}
                     initial={{ opacity: 0, translateX: 100 }}
-                    key={router.query.mdx + componentProps}
                   >
                     <PropTable docData={componentProps} />
                   </motion.div>

--- a/docs/src/pages/docs/[[...mdx]].js
+++ b/docs/src/pages/docs/[[...mdx]].js
@@ -6,7 +6,7 @@ import Head from 'next/head';
 import { AnimatePresence, motion } from 'framer-motion';
 
 import { Tabs } from '../../components';
-import { POSTS_PATH, postFilePaths } from '../../lib/mdxUtils';
+import { postFilePaths, POSTS_PATH } from '../../lib/mdxUtils';
 import MDX_COMPONENTS from '../../lib/MDX_COMPONENTS';
 import MDX_OPTIONS from '../../lib/MDX_OPTIONS';
 import getMDXTree from '../../lib/getMDXTree';
@@ -29,12 +29,12 @@ const propTypes = {
   mdxDirSource: pt.arrayOf(
     pt.shape({
       frontMatter: pt.shape({
-        title: pt.string,
         description: pt.shape(),
+        title: pt.string,
       }),
       frontmatter: pt.shape({
-        title: pt.string,
         description: pt.shape(),
+        title: pt.string,
         type: pt.string,
       }),
       router: pt.shape(),

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,6 +1,6 @@
 import hydrate from 'next-mdx-remote/hydrate';
 import getMDXTree from '../lib/getMDXTree';
-import { POSTS_PATH, postFilePaths } from '../lib/mdxUtils';
+import { postFilePaths, POSTS_PATH } from '../lib/mdxUtils';
 import MDX_COMPONENTS from '../lib/MDX_COMPONENTS';
 import MDX_OPTIONS from '../lib/MDX_OPTIONS';
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,40 +4,30 @@
 module.exports = {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
-
   // Stop running tests after `n` failures
   // bail: 0,
-
   // The directory where Jest should store its cached dependency information
   // cacheDirectory: "/private/var/folders/97/w9yvm2kn0vn8wzfh8hfb3yx00000gp/T/jest_dy",
-
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
-
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: true,
-
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: [
   //   "**/*.{<j></j>s,jsx}",
   //   "!**/node_modules/**",
   //   "!**/*.fixture.js"
   // ],
-
   // The directory where Jest should output its coverage files
   coverageDirectory: '.jest/build/coverage',
-
   // An array of regexp pattern strings used to skip coverage collection
   // coveragePathIgnorePatterns: [
   //   "/node_modules/",
   // ],
-
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: 'babel',
-
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
-
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     // @manu: disabled to unbreak the build
@@ -64,33 +54,24 @@ module.exports = {
     //   statements: 100,
     // },
   },
-
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,
-
   // Make calling deprecated APIs throw helpful error messages
   // errorOnDeprecated: false,
-
   // Force coverage collection from ignored files using an array of glob patterns
   // forceCoverageMatch: [],
-
   // A path to a module which exports an async function that is triggered once before all test suites
   // globalSetup: undefined,
-
   // A path to a module which exports an async function that is triggered once after all test suites
   // globalTeardown: undefined,
-
   // A set of global variables that need to be available in all test environments
   // globals: {},
-
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   // maxWorkers: "50%",
-
   // An array of directory names to be searched recursively up from the requiring module's location
   // moduleDirectories: [
   //   "node_modules"
   // ],
-
   // An array of file extensions your modules use
   // moduleFileExtensions: [
   //   "js",
@@ -100,120 +81,89 @@ module.exports = {
   //   "tsx",
   //   "node"
   // ],
-
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
+    '\\.(css|scss)$': 'identity-obj-proxy',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/__mocks__/fileMock.js',
-    '\\.(css|scss)$': 'identity-obj-proxy',
   },
-
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   modulePathIgnorePatterns: ['.fixture.js'],
-
   // Activates notifications for test results
   // notify: false,
-
   // An enum that specifies notification mode. Requires { notify: true }
   // notifyMode: "failure-change",
-
   // A preset that is used as a base for Jest's configuration
   // preset: undefined,
-
   // Run tests from one or more projects
   // projects: undefined,
-
   // Use this configuration option to add custom reporters to Jest
   // reporters: undefined,
-
   // Automatically reset mock state between every test
   // resetMocks: false,
-
   // Reset the module registry before running each individual test
   // resetModules: false,
-
   // A path to a custom resolver
   // resolver: undefined,
-
   // Automatically restore mock state between every test
   // restoreMocks: false,
-
   // The root directory that Jest should scan for tests and modules within
   // rootDir: undefined,
-
   // A list of paths to directories that Jest should use to search for files in
   roots: ['packages/cascara/src'],
-
   // Allows you to use a custom runner instead of Jest's default test runner
   // runner: "jest-runner",
-
   // The paths to modules that run some code to configure or set up the testing environment before each test
   setupFiles: ['./.jest/setup.js'],
-
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
-
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,
-
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],
-
   snapshotResolver: './.jest/snapshotResolver.js',
-
   // The test environment that will be used for testing
   // testEnvironment: "jest-environment-jsdom",
-
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},
-
   // Adds a location field to test results
   // testLocationInResults: false,
-
   // The glob patterns Jest uses to detect test files
   testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
-
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   // testPathIgnorePatterns: [
   //   "/node_modules/"
   // ],
-
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],
-
   // This option allows the use of a custom results processor
   // testResultsProcessor: undefined,
-
   // This option allows use of a custom test runner
   // testRunner: "jasmine2",
-
   // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
   // testURL: "http://localhost",
-
   // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
   // timers: "real",
-
   // A map from regular expressions to paths to transformers
   // NOTE: This is needed in order for Jest to see the babel.config.js file in the root of the repository
   transform: {
-    '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { rootMode: 'upward' }],
-  },
-
-  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+    '^.+\\.(js|jsx|ts|tsx)$': [
+      'babel-jest',
+      {
+        rootMode: 'upward',
+      },
+    ],
+  }, // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   // transformIgnorePatterns: [
   //   "/node_modules/",
   //   "\\.pnp\\.[^\\/]+$"
   // ],
-
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,
-
   // Indicates whether each individual test should be reported during the run
   // verbose: undefined,
-
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
   // watchPathIgnorePatterns: [],
-
   // Whether to use watchman for file crawling
   // watchman: true,
 };

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "babel-preset": "yarn workspace @espressive/babel-preset-espressive",
     "cascara": "yarn workspace @espressive/cascara",
-    "cosmos:build": "npx -p react-cosmos cosmos-export --config .cosmos/config.json",
-    "cosmos": "npx react-cosmos --config .cosmos/config.json",
+    "cosmos:build": "npx -p react-cosmos@5.5.3 cosmos-export --config .cosmos/config.json",
+    "cosmos": "npx react-cosmos@5.5.3 --config .cosmos/config.json",
     "docs": "yarn workspace docs",
     "eslint-config": "yarn workspace @espressive/eslint-config-espressive",
     "framer:publish": "dotenv npx framer-cli publish",

--- a/packages/cascara/src/fixtures/ReactMemo.fixture.js
+++ b/packages/cascara/src/fixtures/ReactMemo.fixture.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, memo } from 'react';
+import React, { memo, useCallback, useState } from 'react';
 
 const Button = ({ onClick, children }) => {
   console.log('Button rendered');
@@ -15,7 +15,8 @@ const WithoutCallback = () => {
   console.log('WithoutCallback rendered');
   const [count, setCount] = useState(0);
 
-  const handleIncrement = () => setCount(count + 1);
+  const handleIncrement = useCallback(() => setCount(count + 1), [count]);
+
   return (
     <div>
       {count}

--- a/packages/cascara/src/lib/customPropTypes/json.js
+++ b/packages/cascara/src/lib/customPropTypes/json.js
@@ -1,14 +1,12 @@
 // This propType function should validate if we are using JSON data
-
-// eslint-disable-next-line consistent-return -- this can't return anything
-function json(props, propName, componentName) {
+const json = (props, propName, componentName) => {
   try {
-    JSON.parse(props[propName]);
+    return JSON.parse(props[propName]);
   } catch (e) {
     return new Error(
       `Invalid prop \`${propName}\` supplied to \`${componentName}\`. Validation failed.`
     );
   }
-}
+};
 
 export { json };

--- a/packages/cascara/src/lib/customPropTypes/json.js
+++ b/packages/cascara/src/lib/customPropTypes/json.js
@@ -1,6 +1,7 @@
 // This propType function should validate if we are using JSON data
 
-const json = (props, propName, componentName) => {
+// eslint-disable-next-line consistent-return -- this can't return anything
+function json(props, propName, componentName) {
   try {
     JSON.parse(props[propName]);
   } catch (e) {
@@ -8,6 +9,6 @@ const json = (props, propName, componentName) => {
       `Invalid prop \`${propName}\` supplied to \`${componentName}\`. Validation failed.`
     );
   }
-};
+}
 
 export { json };

--- a/packages/cascara/src/modules/ActionButton/ActionButton.js
+++ b/packages/cascara/src/modules/ActionButton/ActionButton.js
@@ -36,9 +36,9 @@ const ActionButton = ({
   // FDS-137: use action name for button name if no content is specified
   const buttonText = content || name;
 
-  const handleClick = ({ currentTarget }) => {
+  function handleClick({ currentTarget }) {
     onAction(currentTarget, record);
-  };
+  }
 
   return isEditing ? null : (
     <Button

--- a/packages/cascara/src/modules/ActionButton/ActionButton.js
+++ b/packages/cascara/src/modules/ActionButton/ActionButton.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import pt from 'prop-types';
 
 import { ModuleContext } from '../context';
@@ -36,9 +36,12 @@ const ActionButton = ({
   // FDS-137: use action name for button name if no content is specified
   const buttonText = content || name;
 
-  function handleClick({ currentTarget }) {
-    onAction(currentTarget, record);
-  }
+  const handleClick = useCallback(
+    ({ currentTarget }) => {
+      onAction(currentTarget, record);
+    },
+    [onAction, record]
+  );
 
   return isEditing ? null : (
     <Button

--- a/packages/cascara/src/modules/ActionEdit/ActionEdit.js
+++ b/packages/cascara/src/modules/ActionEdit/ActionEdit.js
@@ -58,14 +58,14 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
     exitEditMode();
   };
 
-  const handleCancel = () => {
+  function handleCancel() {
     isDirty
       ? // eslint-disable-next-line no-restricted-globals, no-alert -- For now we do not have our own confirmation dialog so we are using native confirms
         confirm('Abandon unsaved changes?') && handleReset()
       : handleReset();
-  };
+  }
 
-  const handleEdit = () => {
+  function handleEdit() {
     // FDS-91: We are resetting the form with whatever is in record.
     // We don't know if this is the best way to do it in React.
     reset({ ...record });
@@ -80,9 +80,9 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
     );
 
     enterEditMode(recordId);
-  };
+  }
 
-  const onSubmit = (data) => {
+  function onSubmit(data) {
     onAction(
       // fake target
       {
@@ -95,7 +95,7 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
     );
 
     exitEditMode();
-  };
+  }
 
   return isEditing ? (
     <>

--- a/packages/cascara/src/modules/ActionEdit/ActionEdit.js
+++ b/packages/cascara/src/modules/ActionEdit/ActionEdit.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import pt from 'prop-types';
 
 import { ModuleContext } from '../context';
@@ -44,7 +44,7 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
     saveTestId['data-testid'] = dataTestIDs['save'];
   }
 
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     onAction(
       // fake target
       {
@@ -56,16 +56,16 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
     );
 
     exitEditMode();
-  };
+  }, [exitEditMode, onAction, record]);
 
-  function handleCancel() {
+  const handleCancel = useCallback(() => {
     isDirty
       ? // eslint-disable-next-line no-restricted-globals, no-alert -- For now we do not have our own confirmation dialog so we are using native confirms
         confirm('Abandon unsaved changes?') && handleReset()
       : handleReset();
-  }
+  }, [handleReset, isDirty]);
 
-  function handleEdit() {
+  const handleEdit = useCallback(() => {
     // FDS-91: We are resetting the form with whatever is in record.
     // We don't know if this is the best way to do it in React.
     reset({ ...record });
@@ -80,22 +80,25 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
     );
 
     enterEditMode(recordId);
-  }
+  }, [enterEditMode, onAction, record, recordId, reset]);
 
-  function onSubmit(data) {
-    onAction(
-      // fake target
-      {
-        name: 'edit.save',
-      },
-      {
-        ...record,
-        ...data,
-      }
-    );
+  const onSubmit = useCallback(
+    (data) => {
+      onAction(
+        // fake target
+        {
+          name: 'edit.save',
+        },
+        {
+          ...record,
+          ...data,
+        }
+      );
 
-    exitEditMode();
-  }
+      exitEditMode();
+    },
+    [exitEditMode, onAction, record]
+  );
 
   return isEditing ? (
     <>

--- a/packages/cascara/src/modules/AllModules.fixture.js
+++ b/packages/cascara/src/modules/AllModules.fixture.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import { ModuleProvider } from './context';
 import FormProvider from '../ui/Form/context/FormProvider';

--- a/packages/cascara/src/modules/DataTextArea/DataTextArea.js
+++ b/packages/cascara/src/modules/DataTextArea/DataTextArea.js
@@ -31,7 +31,6 @@ const DataTextArea = ({
   const { isEditing, formMethods } = useContext(ModuleContext);
 
   const renderEditing = (
-    // eslint-disable-next-line jsx-a11y/label-has-for
     <label htmlFor={label}>
       {label && isLabeled && <span className={styles.Label}>{label}</span>}
       <Input

--- a/packages/cascara/src/modules/ModuleError/ModuleError.js
+++ b/packages/cascara/src/modules/ModuleError/ModuleError.js
@@ -4,7 +4,6 @@ import styles from '../DataModule.module.scss';
 
 const propTypes = {
   moduleName: pt.string.isRequired,
-  // eslint-disable-next-line react/forbid-prop-types -- We do not know what the object params might be in this case
   moduleOptions: pt.arrayOf(pt.object).isRequired,
 };
 
@@ -12,7 +11,7 @@ const ModuleError = ({ moduleName, moduleOptions }) => {
   const message = `${moduleName} is not a valid value for module. Try using one of [${moduleOptions.join(
     ', '
   )}]`;
-  // eslint-disable-next-line no-console
+  // eslint-disable-next-line no-console -- we need to display this error to develop
   console.error(message);
 
   return (

--- a/packages/cascara/src/modules/ModuleError/ModuleError.js
+++ b/packages/cascara/src/modules/ModuleError/ModuleError.js
@@ -11,6 +11,7 @@ const ModuleError = ({ moduleName, moduleOptions }) => {
   const message = `${moduleName} is not a valid value for module. Try using one of [${moduleOptions.join(
     ', '
   )}]`;
+
   // eslint-disable-next-line no-console -- we need to display this error to develop
   console.error(message);
 

--- a/packages/cascara/src/modules/poc/ContextComposability.fixture.js
+++ b/packages/cascara/src/modules/poc/ContextComposability.fixture.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React, { useContext } from 'react';
 import JsonPlaceholder from '../../placeholders/JsonPlaceholder';
 import ReusableModuleContext, { defaultValue } from './ReusableModuleContext';

--- a/packages/cascara/src/modules/poc/ContextComposableActions.fixture.js
+++ b/packages/cascara/src/modules/poc/ContextComposableActions.fixture.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import DataText from '../DataText';
 import ActionButton from '../ActionButton';
@@ -115,7 +114,7 @@ const ContextComposableActions = ({ data, dataConfig }) => {
           <DataText label='Table Level Module' value='Table' />
           <ActionEdit />
           {fakeTableData.map((row, i) => (
-            <FakeRow {...row} />
+            <FakeRow {...row} key={`${row.key}${i}`} />
           ))}
         </AreaPlaceholder>
       </TableProvider>

--- a/packages/cascara/src/placeholders/AreaPlaceholder/AreaPlaceholder.fixture.js
+++ b/packages/cascara/src/placeholders/AreaPlaceholder/AreaPlaceholder.fixture.js
@@ -1,13 +1,7 @@
 import React from 'react';
 import AreaPlaceholder from './AreaPlaceholder';
 
-/* eslint-disable sort-keys */
 export default {
-  default: (
-    <AreaPlaceholder label='Label'>
-      <p>Yo</p>
-    </AreaPlaceholder>
-  ),
   contextExample: (
     <div style={{ padding: '1em' }}>
       <AreaPlaceholder label='Tenant Context'>
@@ -17,5 +11,9 @@ export default {
       </AreaPlaceholder>
     </div>
   ),
+  default: (
+    <AreaPlaceholder label='Label'>
+      <p>Yo</p>
+    </AreaPlaceholder>
+  ),
 };
-/* eslint-enable sort-keys */

--- a/packages/cascara/src/placeholders/JsonPlaceholder/JsonPlaceholder.fixture.js
+++ b/packages/cascara/src/placeholders/JsonPlaceholder/JsonPlaceholder.fixture.js
@@ -8,18 +8,7 @@ const testJson = {
   },
 };
 
-/* eslint-disable sort-keys */
 export default {
-  default: <JsonPlaceholder data={testJson} />,
-  isInitialOpen: <JsonPlaceholder data={testJson} isInitialOpen />,
-  title: <JsonPlaceholder data={testJson} title='Custom Title' />,
-  style: (
-    <JsonPlaceholder
-      data={testJson}
-      style={{ maxWidth: '50%', backgroundColor: 'red' }}
-      title='Style'
-    />
-  ),
   className: (
     <JsonPlaceholder
       className='test-class'
@@ -27,5 +16,17 @@ export default {
       title='Custom className'
     />
   ),
+  default: <JsonPlaceholder data={testJson} />,
+  isInitialOpen: <JsonPlaceholder data={testJson} isInitialOpen />,
+  style: (
+    <JsonPlaceholder
+      data={testJson}
+      style={{
+        backgroundColor: 'red',
+        maxWidth: '50%',
+      }}
+      title='Style'
+    />
+  ),
+  title: <JsonPlaceholder data={testJson} title='Custom Title' />,
 };
-/* eslint-enable sort-keys */

--- a/packages/cascara/src/structures/Admin/Admin.fixture.js
+++ b/packages/cascara/src/structures/Admin/Admin.fixture.js
@@ -106,7 +106,6 @@ const longContent = (
   </ul>
 );
 
-/* eslint-disable sort-keys */
 export default {
   NoDrawer: (
     <Admin
@@ -133,4 +132,3 @@ export default {
     />
   ),
 };
-/* eslint-enable sort-keys */

--- a/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
+++ b/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
@@ -70,6 +70,7 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
                   as='div'
                   className={`item ${styles.ActionsMenuItem}`}
                   key={key}
+                  // eslint-disable-next-line react/jsx-no-bind -- rest needs to be passed, hence the in-situ arrow function
                   onClick={() => handleMenuItemClick(rest)}
                 >
                   {buttonText}

--- a/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
+++ b/packages/cascara/src/ui/ActionsMenu/ActionsMenu.js
@@ -1,12 +1,13 @@
 import pt from 'prop-types';
-import React, { useContext, useRef } from 'react';
-import { Menu, MenuButton, MenuItem, useMenuState } from 'reakit/Menu';
+import React, { useRef } from 'react';
+import { Menu, MenuButton, useMenuState } from 'reakit/Menu';
 import { Button } from 'reakit/Button';
 
+import ActionsMenuItem from './ActionsMenuItem';
 import styles from './ActionsMenu.module.scss';
 import { popperOverTrigger } from '../../shared/popperModifiers';
-import { ModuleContext } from '../../modules/context';
 
+const MemoActionsMenuItem = React.memo(ActionsMenuItem);
 const DEFAULT_TRIGGER = (
   <Button className='ui basic icon button'>
     <b>⋯</b>
@@ -19,8 +20,6 @@ const propTypes = {
 };
 
 const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
-  const { onAction, record } = useContext(ModuleContext);
-
   // Set a ref on our trigger to pass into the disclosure and also measure clientHeight
   const triggerRef = useRef();
 
@@ -33,14 +32,6 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
     preventBodyScroll: true,
     unstable_popperModifiers: [popperOverTrigger],
   });
-
-  const handleMenuItemClick = (item) => {
-    menu.hide();
-
-    if (onAction) {
-      onAction(item, record);
-    }
-  };
 
   return (
     <>
@@ -57,27 +48,14 @@ const ActionsMenu = ({ trigger = DEFAULT_TRIGGER, actions }) => {
           className='menu transition visible'
           style={{ position: 'initial' }}
         >
-          {actions.map(
-            ({ actionName, content, isLabeled, ...rest }, actionIndex) => {
-              // FDS-137: use action name for button name if no content is specified
-              const buttonText = content || rest.name;
-              const key = `action.${actionIndex}-${rest.name}.${content}`;
-
-              return (
-                <MenuItem
-                  {...menu}
-                  {...rest}
-                  as='div'
-                  className={`item ${styles.ActionsMenuItem}`}
-                  key={key}
-                  // eslint-disable-next-line react/jsx-no-bind -- rest needs to be passed, hence the in-situ arrow function
-                  onClick={() => handleMenuItemClick(rest)}
-                >
-                  {buttonText}
-                </MenuItem>
-              );
-            }
-          )}
+          {actions.map((action, actionIndex) => (
+            <MemoActionsMenuItem
+              key={action.name}
+              {...action}
+              actionIndex={actionIndex}
+              menu={menu}
+            />
+          ))}
         </div>
       </Menu>
     </>

--- a/packages/cascara/src/ui/ActionsMenu/ActionsMenuItem.js
+++ b/packages/cascara/src/ui/ActionsMenu/ActionsMenuItem.js
@@ -1,0 +1,67 @@
+import pt from 'prop-types';
+import React, { useCallback, useContext } from 'react';
+import { MenuItem } from 'reakit/Menu';
+
+import styles from './ActionsMenu.module.scss';
+import { ModuleContext } from '../../modules/context';
+
+const propTypes = {
+  actionIndex: pt.number,
+  actionName: pt.string,
+  content: pt.string,
+  isLabeled: pt.bool,
+  menu: pt.shape({
+    hide: pt.func,
+    modal: pt.bool,
+    placement: pt.string,
+    preventBodyScroll: pt.boolean,
+    unstable_popperModifiers: pt.arrayOf(
+      pt.shape({
+        name: pt.string,
+        options: pt.shape({
+          offset: pt.func,
+        }),
+      })
+    ),
+  }),
+};
+
+const ActionsMenuItem = ({
+  actionIndex,
+  actionName,
+  content,
+  isLabeled,
+  menu,
+  ...rest
+}) => {
+  const { onAction, record } = useContext(ModuleContext);
+
+  // FDS-137: use action name for button name if no content is specified
+  const buttonText = content || rest.name;
+  const key = `action.${actionIndex}-${rest.name}.${content}`;
+
+  const handleMenuItemClick = useCallback(() => {
+    menu.hide();
+
+    if (onAction) {
+      onAction({ actionName, content, isLabeled, ...rest }, record);
+    }
+  }, [actionName, content, isLabeled, menu, onAction, record, rest]);
+
+  return (
+    <MenuItem
+      {...menu}
+      {...rest}
+      as='div'
+      className={`item ${styles.ActionsMenuItem}`}
+      key={key}
+      onClick={handleMenuItemClick}
+    >
+      {buttonText}
+    </MenuItem>
+  );
+};
+
+ActionsMenuItem.propTypes = propTypes;
+
+export default ActionsMenuItem;

--- a/packages/cascara/src/ui/Button/Button.fixture.js
+++ b/packages/cascara/src/ui/Button/Button.fixture.js
@@ -6,24 +6,21 @@ const handleAlert = () => alert('Alerted!');
 const ButtonRef = () => {
   const buttonRef = useRef(null);
 
-  const handleRefLog = () => {
+  function handleRefLog() {
     console.log(buttonRef);
     alert('See console for log...');
-  };
+  }
 
-  return (
-    <Button content='Ref' onClick={() => handleRefLog()} ref={buttonRef} />
-  );
+  return <Button content='Ref' onClick={handleRefLog} ref={buttonRef} />;
 };
 
-/* eslint-disable sort-keys */
 export default {
   all: (
     <Button
       content='content'
       fluid={false}
       isBrandColor={false}
-      onClick={() => handleAlert()}
+      onClick={handleAlert}
       outcome='positive'
     />
   ),
@@ -36,11 +33,10 @@ export default {
       </button>
     </div>
   ),
-  positive: <Button content='Positive' outcome='positive' />,
-  negative: <Button content='Negative' outcome='negative' />,
   link: (
     <Button as='a' content='Link' href='https://google.com' target='_blank' />
   ),
+  negative: <Button content='Negative' outcome='negative' />,
+  positive: <Button content='Positive' outcome='positive' />,
   ref: <ButtonRef />,
 };
-/* eslint-enable sort-keys */

--- a/packages/cascara/src/ui/Button/Button.fixture.js
+++ b/packages/cascara/src/ui/Button/Button.fixture.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { Button } from '../../../src';
 
 const handleAlert = () => alert('Alerted!');
@@ -6,10 +6,10 @@ const handleAlert = () => alert('Alerted!');
 const ButtonRef = () => {
   const buttonRef = useRef(null);
 
-  function handleRefLog() {
+  const handleRefLog = useCallback(() => {
     console.log(buttonRef);
     alert('See console for log...');
-  }
+  }, []);
 
   return <Button content='Ref' onClick={handleRefLog} ref={buttonRef} />;
 };

--- a/packages/cascara/src/ui/Chat/ChatAttachment.js
+++ b/packages/cascara/src/ui/Chat/ChatAttachment.js
@@ -18,11 +18,11 @@ const propTypes = {
   handleScrollToBottom: pt.func.isRequired,
   isSessionUser: pt.bool,
   metadata: pt.shape({
-    url: pt.string,
-    size: pt.oneOf([pt.number, pt.string]),
-    width: pt.number,
     height: pt.number,
+    size: pt.oneOf([pt.number, pt.string]),
     type: pt.string,
+    url: pt.string,
+    width: pt.number,
   }).isRequired,
   timestamp: pt.string.isRequired,
 };

--- a/packages/cascara/src/ui/Chat/ChatOptions.js
+++ b/packages/cascara/src/ui/Chat/ChatOptions.js
@@ -4,8 +4,8 @@ import {
   Animation,
   Button,
   Dropdown,
-  Chat as FUIChat,
   Flex,
+  Chat as FUIChat,
   Ref,
 } from '@fluentui/react-northstar';
 import { getChatMessageObj } from './ChatMessage';
@@ -24,6 +24,10 @@ const propTypes = {
   timestamp: pt.string.isRequired,
 };
 
+function itemToString(value) {
+  return value.content;
+}
+
 /** A Chat can display options as either buttons or a dropdown select if more than 3 options exist */
 const ChatOptions = ({
   authorName,
@@ -37,7 +41,7 @@ const ChatOptions = ({
       content={
         options.length > 3 ? (
           <Dropdown
-            itemToString={(value) => value.content}
+            itemToString={itemToString}
             items={options.map((option, i) => ({
               ...option,
             }))}
@@ -47,7 +51,7 @@ const ChatOptions = ({
         ) : (
           <Flex column gap='gap.small'>
             {options.map((option) => (
-              <Button {...option} fluid />
+              <Button {...option} fluid key={option.key} />
             ))}
           </Flex>
         )

--- a/packages/cascara/src/ui/Chat/ChatOptions.js
+++ b/packages/cascara/src/ui/Chat/ChatOptions.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import pt from 'prop-types';
 import {
   Animation,
@@ -24,43 +24,45 @@ const propTypes = {
   timestamp: pt.string.isRequired,
 };
 
-function itemToString(value) {
-  return value.content;
-}
-
 /** A Chat can display options as either buttons or a dropdown select if more than 3 options exist */
 const ChatOptions = ({
   authorName,
   isSessionUser = false,
   options = [],
   timestamp,
-}) => (
-  <Animation name='chatMessage'>
-    <FUIChat.Message
-      author={authorName}
-      content={
-        options.length > 3 ? (
-          <Dropdown
-            itemToString={itemToString}
-            items={options.map((option, i) => ({
-              ...option,
-            }))}
-            noResultsMessage="We couldn't find any matches."
-            placeholder='Select an option...'
-          />
-        ) : (
-          <Flex column gap='gap.small'>
-            {options.map((option) => (
-              <Button {...option} fluid key={option.key} />
-            ))}
-          </Flex>
-        )
-      }
-      mine={isSessionUser}
-      timestamp={timestamp}
-    />
-  </Animation>
-);
+}) => {
+  const itemToString = useCallback((value) => {
+    return value.content;
+  }, []);
+
+  return (
+    <Animation name='chatMessage'>
+      <FUIChat.Message
+        author={authorName}
+        content={
+          options.length > 3 ? (
+            <Dropdown
+              itemToString={itemToString}
+              items={options.map((option, i) => ({
+                ...option,
+              }))}
+              noResultsMessage="We couldn't find any matches."
+              placeholder='Select an option...'
+            />
+          ) : (
+            <Flex column gap='gap.small'>
+              {options.map((option) => (
+                <Button {...option} fluid key={option.key} />
+              ))}
+            </Flex>
+          )
+        }
+        mine={isSessionUser}
+        timestamp={timestamp}
+      />
+    </Animation>
+  );
+};
 
 ChatOptions.displayName = 'Chat.Options';
 ChatOptions.propTypes = propTypes;

--- a/packages/cascara/src/ui/Chat/ChatProvider.js
+++ b/packages/cascara/src/ui/Chat/ChatProvider.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import pt from 'prop-types';
 import {
   Dropdown,
@@ -72,9 +72,12 @@ const propTypes = {
 const ChatProvider = ({ children, inputComponent, isThemeSelectable }) => {
   const [theme, setTheme] = useState(items[DEFAULT_THEME_INDEX].value);
 
-  function handleDropdownChange(e, data) {
-    setTheme(data.value.value);
-  }
+  const handleDropdownChange = useCallback(
+    (e, data) => {
+      setTheme(data.value.value);
+    },
+    [setTheme]
+  );
 
   return (
     <Provider theme={themes[theme]}>

--- a/packages/cascara/src/ui/Chat/ChatProvider.js
+++ b/packages/cascara/src/ui/Chat/ChatProvider.js
@@ -72,6 +72,10 @@ const propTypes = {
 const ChatProvider = ({ children, inputComponent, isThemeSelectable }) => {
   const [theme, setTheme] = useState(items[DEFAULT_THEME_INDEX].value);
 
+  function handleDropdownChange(e, data) {
+    setTheme(data.value.value);
+  }
+
   return (
     <Provider theme={themes[theme]}>
       <Flex column gap='gap.small' style={{ maxHeight: '100vh' }}>
@@ -83,7 +87,7 @@ const ChatProvider = ({ children, inputComponent, isThemeSelectable }) => {
               items={items.map((option) => ({
                 ...option,
               }))}
-              onChange={(e, data) => setTheme(data.value.value)}
+              onChange={handleDropdownChange}
               placeholder='Select a theme'
             />
           </div>

--- a/packages/cascara/src/ui/Chat/ChatTyping.js
+++ b/packages/cascara/src/ui/Chat/ChatTyping.js
@@ -17,6 +17,11 @@ const propTypes = {
 
 /** A Chat can display an indicator that typing is happening */
 const ChatTyping = ({ isSessionUser = false }) => {
+  function handleMoreIconClick({ theme: { siteVariables } }) {
+    return {
+      color: siteVariables?.colorScheme?.brand?.foreground,
+    };
+  }
   return (
     <Animation name='chatMessage'>
       <FUIChat.Message
@@ -29,12 +34,7 @@ const ChatTyping = ({ isSessionUser = false }) => {
             }}
           >
             <Animation name='wiggle'>
-              <MoreIcon
-                size='larger'
-                styles={({ theme: { siteVariables } }) => ({
-                  color: siteVariables?.colorScheme?.brand?.foreground,
-                })}
-              />
+              <MoreIcon size='larger' styles={handleMoreIconClick} />
             </Animation>
           </Provider>
         }

--- a/packages/cascara/src/ui/Chat/ChatTyping.js
+++ b/packages/cascara/src/ui/Chat/ChatTyping.js
@@ -15,35 +15,34 @@ const propTypes = {
   isSessionUser: pt.bool,
 };
 
-/** A Chat can display an indicator that typing is happening */
-const ChatTyping = ({ isSessionUser = false }) => {
-  function handleMoreIconClick({ theme: { siteVariables } }) {
-    return {
-      color: siteVariables?.colorScheme?.brand?.foreground,
-    };
-  }
-  return (
-    <Animation name='chatMessage'>
-      <FUIChat.Message
-        content={
-          <Provider
-            theme={{
-              animations: {
-                wiggle,
-              },
-            }}
-          >
-            <Animation name='wiggle'>
-              <MoreIcon size='larger' styles={handleMoreIconClick} />
-            </Animation>
-          </Provider>
-        }
-        mine={isSessionUser}
-        style={{ minWidth: 'auto' }}
-      />
-    </Animation>
-  );
+const handleMoreIconClick = ({ theme: { siteVariables } }) => {
+  return {
+    color: siteVariables?.colorScheme?.brand?.foreground,
+  };
 };
+
+/** A Chat can display an indicator that typing is happening */
+const ChatTyping = ({ isSessionUser = false }) => (
+  <Animation name='chatMessage'>
+    <FUIChat.Message
+      content={
+        <Provider
+          theme={{
+            animations: {
+              wiggle,
+            },
+          }}
+        >
+          <Animation name='wiggle'>
+            <MoreIcon size='larger' styles={handleMoreIconClick} />
+          </Animation>
+        </Provider>
+      }
+      mine={isSessionUser}
+      style={{ minWidth: 'auto' }}
+    />
+  </Animation>
+);
 
 ChatTyping.displayName = 'Chat.Typing';
 ChatTyping.propTypes = propTypes;

--- a/packages/cascara/src/ui/Chat/ChatWidget/index.js
+++ b/packages/cascara/src/ui/Chat/ChatWidget/index.js
@@ -33,7 +33,7 @@ const getChatWidgetObj = (obj) => {
   // This message may need to be separated to throw errors on other components like
   // system type messages
   if (message.user_id !== (undefined || null)) {
-    // eslint-disable-next-line no-console
+    // eslint-disable-next-line no-console -- this message is needed
     console.error('System widgets should not include a `user_id` key.');
   }
   return {

--- a/packages/cascara/src/ui/Chat/ChatWidget/index.js
+++ b/packages/cascara/src/ui/Chat/ChatWidget/index.js
@@ -33,7 +33,7 @@ const getChatWidgetObj = (obj) => {
   // This message may need to be separated to throw errors on other components like
   // system type messages
   if (message.user_id !== (undefined || null)) {
-    // eslint-disable-next-line no-console -- this message is needed
+    // eslint-disable-next-line no-console -- this is needed as a developer message
     console.error('System widgets should not include a `user_id` key.');
   }
   return {

--- a/packages/cascara/src/ui/Chat/fixtures/ChatPublicAPI.fixture.js
+++ b/packages/cascara/src/ui/Chat/fixtures/ChatPublicAPI.fixture.js
@@ -4,14 +4,13 @@ import {
   Button,
   Flex,
   Provider,
-  TextArea,
   teamsTheme,
+  TextArea,
 } from '@fluentui/react-northstar';
 import { getNormalizedMessages } from './utils';
 
 import { results as convo0 } from '../json/conversation0';
 import { results as convo1 } from '../json/conversation1';
-// import { results as convo2 } from '../json/conversation2';
 
 const teamsCommentsTheme = {
   componentStyles: {
@@ -105,11 +104,9 @@ const TeamsChatExample = (
   </Provider>
 );
 
-/* eslint-disable sort-keys */
 export default {
   default: ChatPublicAPI,
-  no_users: ChatNoUsers,
   no_messages: ChatNoMessages,
+  no_users: ChatNoUsers,
   teams: TeamsChatExample,
 };
-/* eslint-enable sort-keys */

--- a/packages/cascara/src/ui/Chat/fixtures/utils/currentPlatform.js
+++ b/packages/cascara/src/ui/Chat/fixtures/utils/currentPlatform.js
@@ -3,19 +3,19 @@ const platforms = {
   electron: Boolean(process.versions['electron']),
 };
 
-const getCurrentPlatform = () => {
+function getCurrentPlatform() {
+  // If we do not match any other platform, set `web` as our platform
+  let finalPlatform = 'web';
+
   for (const platform in platforms) {
     if (platforms[platform]) {
       // Once we match a platform we return and do not test any other platforms,
       // so the order of the `platforms` object is potentially important.
-      return platform;
-    } else {
-      // If we do not match any other platform, set `web` as our platform
-      return 'web';
+      finalPlatform = platform;
     }
   }
-};
 
-const currentPlatform = getCurrentPlatform();
+  return finalPlatform;
+}
 
-export { currentPlatform };
+export const currentPlatform = getCurrentPlatform();

--- a/packages/cascara/src/ui/Chat/utils/getMessageGroup.js
+++ b/packages/cascara/src/ui/Chat/utils/getMessageGroup.js
@@ -12,12 +12,10 @@ const getMessageGroup = (
   const { sys_date_created: previousUTC, user_id: previousUser } = previous;
   const { sys_date_created: nextUTC, user_id: nextUser } = next;
 
-  /* eslint-disable sort-keys */
-
   const time = {
-    prev: new Date(previousUTC).getTime(),
     current: new Date(currentUTC).getTime(),
     next: new Date(nextUTC).getTime(),
+    prev: new Date(previousUTC).getTime(),
   };
   const timeDiffMins = 15;
   const prevMinDiff = Math.floor((time.current - time.prev) / 1000 / 60);
@@ -25,14 +23,14 @@ const getMessageGroup = (
 
   // Messages can be grouped in two scenarios:
   const userGroup = {
-    top: previousUser !== currentUser && nextUser === currentUser,
-    middle: previousUser === currentUser && nextUser === currentUser,
     bottom: nextUser !== currentUser && previousUser === currentUser,
+    middle: previousUser === currentUser && nextUser === currentUser,
+    top: previousUser !== currentUser && nextUser === currentUser,
   };
   const timeRangeGroup = {
-    top: previousUser === currentUser && prevMinDiff > timeDiffMins,
-    middle: prevMinDiff < timeDiffMins && nextMinDiff < timeDiffMins,
     bottom: nextUser === currentUser && nextMinDiff > timeDiffMins,
+    middle: prevMinDiff < timeDiffMins && nextMinDiff < timeDiffMins,
+    top: previousUser === currentUser && prevMinDiff > timeDiffMins,
   };
 
   let messageGrouping;
@@ -62,8 +60,6 @@ const getMessageGroup = (
   //   nextTimeDiff: nextMinDiff,
   //   attachment,
   // });
-
-  /* eslint-enable sort-keys */
 
   // Any message not in a group should not have any messageGrouping (return undefined)
   return messageGrouping;

--- a/packages/cascara/src/ui/Dashboard/poc/DashboardPAC.fixture.js
+++ b/packages/cascara/src/ui/Dashboard/poc/DashboardPAC.fixture.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import { Container } from 'semantic-ui-react';
 import Dashboard from '../Dashboard';

--- a/packages/cascara/src/ui/Form/context/FormProvider.js
+++ b/packages/cascara/src/ui/Form/context/FormProvider.js
@@ -15,8 +15,7 @@ const FormProvider = ({ children, value, ...props }) => {
   const { handleSubmit } = formMethods;
 
   const onSubmit = (data) => {
-    // eslint-disable-next-line no-console
-    console.table(data);
+    return data;
   };
 
   const mergedValues = {

--- a/packages/cascara/src/ui/Form/poc/FormPublicAPI.fixture.js
+++ b/packages/cascara/src/ui/Form/poc/FormPublicAPI.fixture.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import faker from 'faker';
 import JsonPlaceholder from '../../../placeholders/JsonPlaceholder';

--- a/packages/cascara/src/ui/Pagination/Pagination.js
+++ b/packages/cascara/src/ui/Pagination/Pagination.js
@@ -53,7 +53,7 @@ const Pagination = ({
   // @param {Object} component Component object passed by SUIR
   // @param {String} component.name The name of the component
   // @param {Any} component.value The new value in the component
-  const handlePaginationChange = (_, component) => {
+  function handlePaginationChange(_, component) {
     let newPage = currentPage;
     let newitemsPerPageLimit = itemsPerPageLimit;
 
@@ -74,7 +74,7 @@ const Pagination = ({
       limit: newitemsPerPageLimit,
       page: newPage,
     });
-  };
+  }
 
   //
   // Handles button's click event
@@ -85,7 +85,7 @@ const Pagination = ({
   // @param {Event} _ Usually the click event
   // @param {Object} component Component object passed by SUIR
   // @param {String} component.name The name of the component
-  const handleButtonClick = (_, button) => {
+  function handleButtonClick(_, button) {
     let newPage = currentPage;
 
     if (button.name === 'forward') {
@@ -98,7 +98,7 @@ const Pagination = ({
       name: 'page',
       value: newPage,
     });
-  };
+  }
 
   const availablePages = Math.ceil(recordCount / itemsPerPageLimit) || 1;
   const canGoForward = currentPage < availablePages;
@@ -137,7 +137,6 @@ const Pagination = ({
     }));
 
   const itemsPerPageLimitSelect = () => (
-    // eslint-disable-next-line jsx-a11y/label-has-for
     <label className={cx({ label: true })} htmlFor={'itemsPerPageLimit'}>
       {`${entityNamePlural} per page:`}
       <Select
@@ -154,7 +153,6 @@ const Pagination = ({
   );
 
   const pageSelect = () => (
-    // eslint-disable-next-line jsx-a11y/label-has-for
     <label className={cx({ label: true })} htmlFor={'page'}>
       {'Page '}
       <Select

--- a/packages/cascara/src/ui/Pagination/Pagination.js
+++ b/packages/cascara/src/ui/Pagination/Pagination.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import pt from 'prop-types';
 import classNames from 'classnames/bind';
 import { noop } from 'lodash';
@@ -53,28 +53,31 @@ const Pagination = ({
   // @param {Object} component Component object passed by SUIR
   // @param {String} component.name The name of the component
   // @param {Any} component.value The new value in the component
-  function handlePaginationChange(_, component) {
-    let newPage = currentPage;
-    let newitemsPerPageLimit = itemsPerPageLimit;
+  const handlePaginationChange = useCallback(
+    (_, component) => {
+      let newPage = currentPage;
+      let newitemsPerPageLimit = itemsPerPageLimit;
 
-    if (component.name === 'page') {
-      newPage = component.value;
-    }
-
-    if (component.name === 'itemsPerPageLimit') {
-      newitemsPerPageLimit = component.value;
-
-      // safeguard
-      if (newitemsPerPageLimit >= recordCount) {
-        newPage = 1;
+      if (component.name === 'page') {
+        newPage = component.value;
       }
-    }
 
-    onPaginationChange({
-      limit: newitemsPerPageLimit,
-      page: newPage,
-    });
-  }
+      if (component.name === 'itemsPerPageLimit') {
+        newitemsPerPageLimit = component.value;
+
+        // safeguard
+        if (newitemsPerPageLimit >= recordCount) {
+          newPage = 1;
+        }
+      }
+
+      onPaginationChange({
+        limit: newitemsPerPageLimit,
+        page: newPage,
+      });
+    },
+    [currentPage, itemsPerPageLimit, onPaginationChange, recordCount]
+  );
 
   //
   // Handles button's click event
@@ -85,20 +88,23 @@ const Pagination = ({
   // @param {Event} _ Usually the click event
   // @param {Object} component Component object passed by SUIR
   // @param {String} component.name The name of the component
-  function handleButtonClick(_, button) {
-    let newPage = currentPage;
+  const handleButtonClick = useCallback(
+    (_, button) => {
+      let newPage = currentPage;
 
-    if (button.name === 'forward') {
-      newPage++;
-    } else {
-      newPage--;
-    }
+      if (button.name === 'forward') {
+        newPage++;
+      } else {
+        newPage--;
+      }
 
-    handlePaginationChange(null, {
-      name: 'page',
-      value: newPage,
-    });
-  }
+      handlePaginationChange(null, {
+        name: 'page',
+        value: newPage,
+      });
+    },
+    [currentPage, handlePaginationChange]
+  );
 
   const availablePages = Math.ceil(recordCount / itemsPerPageLimit) || 1;
   const canGoForward = currentPage < availablePages;

--- a/packages/cascara/src/ui/Popover/Popover.fixture.js
+++ b/packages/cascara/src/ui/Popover/Popover.fixture.js
@@ -38,6 +38,7 @@ const ActionsMenuFixture = (
   </main>
 );
 
-/* eslint-disable sort-keys */
-export default { Popover: PopoverFixture, ActionsMenu: ActionsMenuFixture };
-/* eslint-enable sort-keys */
+export default {
+  ActionsMenu: ActionsMenuFixture,
+  Popover: PopoverFixture,
+};

--- a/packages/cascara/src/ui/Section/Section.fixture.js
+++ b/packages/cascara/src/ui/Section/Section.fixture.js
@@ -6,7 +6,7 @@ import Section from './Section';
 const sectionHeader = (
   <div className='ui fluid icon input'>
     <Input style={{ borderRadius: '2em' }} type='text' />
-    <i aria-hidden='true' class='search icon' />
+    <i aria-hidden='true' className='search icon' />
   </div>
 );
 

--- a/packages/cascara/src/ui/Table/Table.js
+++ b/packages/cascara/src/ui/Table/Table.js
@@ -89,7 +89,7 @@ const Table = ({
   const unwantedActions = dataConfig?.actions;
   if (unwantedActions) {
     modules = unwantedActions;
-    // eslint-disable-next-line no-console
+    // eslint-disable-next-line no-console -- we need to let developers know about this error
     console.warn(
       'Prop "dataConfig.actions" has been deprecated. Actions have been moved to the root of the Table component as their own prop.'
     );
@@ -98,7 +98,7 @@ const Table = ({
   const unwantedActionButtonIndex = dataConfig?.actionButtonMenuIndex;
   if (unwantedActionButtonIndex) {
     actionButtonMenuIndex = unwantedActionButtonIndex;
-    // eslint-disable-next-line no-console
+    // eslint-disable-next-line no-console -- we need to let developers know about this error
     console.warn(
       'Prop "dataConfig.actionButtonIndex" has been deprecated. Actions have been moved to the root of the Table component as their own prop.'
     );

--- a/packages/cascara/src/ui/Table/Table.test.js
+++ b/packages/cascara/src/ui/Table/Table.test.js
@@ -326,7 +326,7 @@ describe('Table', () => {
     // 1.- the events are actualy emitted by the Table
     // 2.- the data reflects the changes made by the user
     // 3.- the number of buttons present in each case.
-    test('editable records', async (done) => {
+    test('editable records', async () => {
       const testEmail = 'engineering@espressive.com';
       const onAction = jest.fn();
 
@@ -414,8 +414,6 @@ describe('Table', () => {
           title: 'District Operations Officer',
         })
       );
-
-      done();
     });
 
     //
@@ -518,7 +516,7 @@ describe('Table', () => {
       );
     });
 
-    // eslint-disable-next-line jest/no-commented-out-tests
+    // eslint-disable-next-line jest/no-commented-out-tests -- these two break the build
     // test('actions with non-existent module', () => {
     //   const wrongModuleName = 'Superdooper';
     //   render(
@@ -548,7 +546,7 @@ describe('Table', () => {
     //   expect(moduleError).toBeTruthy();
     // });
 
-    // eslint-disable-next-line jest/no-commented-out-tests
+    // eslint-disable-next-line jest/no-commented-out-tests -- these two break the build
     // test('columns with non-existent module', () => {
     //   const wrongModuleName = 'Superdooper';
     //   render(

--- a/packages/cascara/src/ui/Table/Table.test.js
+++ b/packages/cascara/src/ui/Table/Table.test.js
@@ -516,7 +516,7 @@ describe('Table', () => {
       );
     });
 
-    // eslint-disable-next-line jest/no-commented-out-tests -- these two break the build
+    // eslint-disable-next-line jest/no-commented-out-tests -- @manu todo: FDS-154 - resolve failint negative tests
     // test('actions with non-existent module', () => {
     //   const wrongModuleName = 'Superdooper';
     //   render(
@@ -546,7 +546,7 @@ describe('Table', () => {
     //   expect(moduleError).toBeTruthy();
     // });
 
-    // eslint-disable-next-line jest/no-commented-out-tests -- these two break the build
+    // eslint-disable-next-line jest/no-commented-out-tests -- @manu todo: FDS-154 - resolve failint negative tests
     // test('columns with non-existent module', () => {
     //   const wrongModuleName = 'Superdooper';
     //   render(

--- a/packages/cascara/src/ui/Table/atoms/SelectionToggle.js
+++ b/packages/cascara/src/ui/Table/atoms/SelectionToggle.js
@@ -26,7 +26,7 @@ const SelectionToggle = ({ id }) => {
   const checked = id !== '__ALL__' ? selection.includes(id) : someItemsSelected;
   const indeterminate = id ? false : !allItemsSelected;
 
-  const handleSelectionToggle = ({ checked, name }) => {
+  function handleSelectionToggle({ checked, name }) {
     if (name === '__ALL__') {
       if (checked) {
         selectAll();
@@ -40,7 +40,7 @@ const SelectionToggle = ({ id }) => {
         addToSelection(name);
       }
     }
-  };
+  }
 
   return (
     <CheckBox

--- a/packages/cascara/src/ui/Table/atoms/SelectionToggle.js
+++ b/packages/cascara/src/ui/Table/atoms/SelectionToggle.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import pt from 'prop-types';
 
 import CheckBox from '../../Checkbox';
@@ -26,21 +26,24 @@ const SelectionToggle = ({ id }) => {
   const checked = id !== '__ALL__' ? selection.includes(id) : someItemsSelected;
   const indeterminate = id ? false : !allItemsSelected;
 
-  function handleSelectionToggle({ checked, name }) {
-    if (name === '__ALL__') {
-      if (checked) {
-        selectAll();
+  const handleSelectionToggle = useCallback(
+    ({ checked, name }) => {
+      if (name === '__ALL__') {
+        if (checked) {
+          selectAll();
+        } else {
+          clearSelection();
+        }
       } else {
-        clearSelection();
+        if (selection.includes(name)) {
+          removeFromSelection(name);
+        } else {
+          addToSelection(name);
+        }
       }
-    } else {
-      if (selection.includes(name)) {
-        removeFromSelection(name);
-      } else {
-        addToSelection(name);
-      }
-    }
-  }
+    },
+    [selectAll, clearSelection, removeFromSelection, addToSelection, selection]
+  );
 
   return (
     <CheckBox

--- a/packages/cascara/src/ui/Table/fixtures/Selection.js
+++ b/packages/cascara/src/ui/Table/fixtures/Selection.js
@@ -65,7 +65,9 @@ const Table = () => {
     uniqueIdAttribute,
   } = useContext(TableContext);
 
-  const columns = dataConfig.display.map((column) => <th>{column.label}</th>);
+  const columns = dataConfig.display.map((column) => (
+    <th key={column.label}>{column.label}</th>
+  ));
   if (bulkActions.length) {
     columns.push(<th />);
   }
@@ -101,14 +103,14 @@ const Table = () => {
   // this will have its own context
   const renderRow = (row) => (
     <tr>
-      {[<td>[]</td>].concat(
-        dataConfig.display.map((column) => (
+      {[<td key={`${row[uniqueIdAttribute]}`}>[]</td>].concat(
+        dataConfig.display.map((column, i) => (
           <td key={`${row[uniqueIdAttribute]}-${row[column.attribute]}`}>
             {row[column.attribute]}
           </td>
         )),
         [
-          <td>
+          <td key={`${row[uniqueIdAttribute]}0`}>
             {actions.map((action) => (
               <button key={action.label} type='button'>
                 {action.label}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,16 +13,15 @@ const getBabelOptions = ({
   babelConfigFile = '../../babel.config.js',
   useESModules,
 }) => ({
-  exclude: '**/node_modules/**',
   babelHelpers: 'runtime',
   configFile: babelConfigFile,
+  exclude: '**/node_modules/**',
   plugins: [['@babel/plugin-transform-runtime', { useESModules }]],
 });
 
 // Also making this a function since we may need to move some of the PostCSS config to the package root to be used in Cosmos or Doc tooling.
 const getPostCSSOptions = () => ({
   // extract: 'styles.css',
-  sourceMap: true,
   minimize: true,
   modules: {
     generateScopedName: function (name, filename, css) {
@@ -35,6 +34,7 @@ const getPostCSSOptions = () => ({
       return `☕️_${file}_${name}__${hash}`;
     },
   },
+  sourceMap: true,
   use: ['sass'],
 });
 
@@ -63,12 +63,12 @@ const getRollupConfig = ({ pwd, babelConfigFile }) => {
 
   // Common JS configuration
   const cjsConfig = {
+    external,
     input,
     output: {
       dir: `${SOURCE_DIR}/${pkgConfig.main.replace('/index.js', '')}`,
       format: 'cjs',
     },
-    external,
     plugins: [
       babel(
         getBabelOptions({
@@ -84,12 +84,12 @@ const getRollupConfig = ({ pwd, babelConfigFile }) => {
 
   // Modules configuration
   const esConfig = {
+    external,
     input,
     output: {
       dir: `${SOURCE_DIR}/${pkgConfigModule.replace('/index.js', '')}`,
       format: 'es',
     },
-    external,
     plugins: [
       babel(
         getBabelOptions({


### PR DESCRIPTION
### Resolves FDS-153

#### Fix eslint rules:
```
consistent-return
eslint-comments/disable-enable-pair
eslint-comments/no-unused-disable
eslint-comments/require-description
jest/no-done-callback
react/jsx-key
react/jsx-no-bind
react/no-unknown-property
sort-imports
sort-keys
```

#### Dependencies
There was a new release of `React Cosmos` ([v5.6.0](https://github.com/react-cosmos/react-cosmos/releases)) [Upgraded to webpack 5 and removed Node 8 support (#1284)](https://github.com/react-cosmos/react-cosmos/commit/dbe83a74f53de7ae3dd61f822aec56e673f725b9). We are sticking to `v5.5.3`, hence the update to `package.json`.