### PR TITLE
chore(FDS-155): React.memo and useCallback example

### DIFF
--- a/packages/cascara/src/fixtures/ReactMemo.fixture.js
+++ b/packages/cascara/src/fixtures/ReactMemo.fixture.js
@@ -1,0 +1,54 @@
+import React, { useState, useCallback, memo } from 'react';
+
+const Button = ({ onClick, children }) => {
+  console.log('Button rendered');
+  return (
+    <button onClick={onClick} type='button'>
+      {children}
+    </button>
+  );
+};
+
+const MemoButton = memo(Button);
+
+const WithoutCallback = () => {
+  console.log('WithoutCallback rendered');
+  const [count, setCount] = useState(0);
+
+  const handleIncrement = () => setCount(count + 1);
+  return (
+    <div>
+      {count}
+      <MemoButton onClick={handleIncrement}>+</MemoButton>
+    </div>
+  );
+};
+
+const WithCallback = () => {
+  console.log('WithCallback rendered');
+  const [count, setCount] = useState(0);
+  // Note we are using `count` as a callback here to make sure its value is not stale
+  // from the last render. We should be aware of this in our components for values as well.
+  const handleIncrement = useCallback(() => setCount((count) => count + 1), []);
+  return (
+    <div>
+      {count}
+      <MemoButton onClick={handleIncrement}>+</MemoButton>
+    </div>
+  );
+};
+
+const Fixture = () => (
+  <>
+    <h2>Prevent Re-Renders With useCallback and React.memo</h2>
+    <p>
+      This fixture outputs console.log messages showing each time each of these
+      components gets rendered and each time the memoized button inside gets
+      rendered.
+    </p>
+    <WithoutCallback />
+    <WithCallback />
+  </>
+);
+
+export default Fixture;


### PR DESCRIPTION
Resolves FDS-155

This fixture should show what happens when we have a handler function that is not wrapped with `useCallback` and how that impacts the use of `React.memo`.

We might actually want to create a collection of fixtures like this to share with the FE team. Hmm…