### PR TITLE
chore(FDS-159) Auto publish packages with Lerna from `main` and prerelease from `develop`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
       - run:
           name: Build Cascara Runtimes
-          command: make
+          command: yarn cascara build
       - save_cache:
           key: cascara-CASCARA_RUNTIMES-{{ .Revision }}-{{ checksum "yarn.lock" }}
           paths:
@@ -128,20 +128,9 @@ jobs:
 
   release:
     <<: *job_executor
-    # docker:
-    #   - image: circleci/node
-    # resource_class: small
     steps:
       - restore_cache:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
-      # - node/with-cache:
-      #     steps:
-      #       - add_ssh_keys:
-      #           fingerprints:
-      #             - $GITHUB_PACKAGE_DEPLOY_FINGERPRINT
-      - run:
-          name: Prepare Lerna
-          command: yarn lerna bootstrap --hoist --ci
       - run:
           name: Publish Cascara
           command: yarn lerna version --no-private --conventional-commits --create-release github --yes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,12 +128,17 @@ jobs:
 
   release:
     <<: *job_executor
+    parameters:
+      options:
+        description: 'Option flags passed to the Lerna release command'
+        default: ''
+        type: string
     steps:
       - restore_cache:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
       - run:
           name: Publish Cascara
-          command: yarn publish-packages --yes
+          command: yarn publish-packages << parameters.options >> --yes
 
 workflows:
   build-and-test:
@@ -163,6 +168,16 @@ workflows:
       - release:
           filters:
             branches:
-              only: main
+              only:
+                - develop
+          options: prerelease
+          requires:
+            - build-cascara
+      - release:
+          filters:
+            branches:
+              only:
+                - main
+          options: --conventional-graduate
           requires:
             - build-cascara

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,13 +134,17 @@ jobs:
     steps:
       - restore_cache:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
-      - node/with-cache:
-          steps:
-            - add_ssh_keys:
-                fingerprints:
-                  - $GITHUB_PACKAGE_DEPLOY_FINGERPRINT
-            - run: yarn lerna bootstrap --hoist --ci
-            - run: yarn lerna version --no-private --conventional-commits --create-release github --yes
+      # - node/with-cache:
+      #     steps:
+      #       - add_ssh_keys:
+      #           fingerprints:
+      #             - $GITHUB_PACKAGE_DEPLOY_FINGERPRINT
+      - run:
+          name: Prepare Lerna
+          command: yarn lerna bootstrap --hoist --ci
+      - run:
+          name: Publish Cascara
+          command: yarn lerna version --no-private --conventional-commits --create-release github --yes
 
 workflows:
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
       - run:
           name: Publish Cascara
-          command: yarn lerna version --no-private --conventional-commits --create-release github --yes
+          command: yarn publish-packages --yes
 
 workflows:
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,28 +3,14 @@ version: 2.1
 orbs:
   node: circleci/node@4.0.1
   slack: circleci/slack@4.2.1
-  # ghpr: narrativescience/ghpr@1.1.1
-  # jq: circleci/jq@2.2.0
 
 job_executor: &job_executor
   executor:
     name: node/default
     tag: '12.13.0'
 
-# GITHUB_PR_BASE_BRANCH` - The base branch for the PR.
-# GITHUB_PR_NUMBER` - The number of the PR.
-# GITHUB_PR_TITLE` - The title of the PR.
-# GITHUB_PR_COMMIT_MESSAGE` - The current commit's message. (Optional)
-# GITHUB_PR_AUTHOR_USERNAME` - The PR author's username.
-# GITHUB_PR_AUTHOR_NAME` - The PR author's name. (Optional)
-# GITHUB_PR_AUTHOR_EMAIL` - The PR author's email address. (Optional)
-
 post_steps: &post_steps
   post-steps:
-    # - jq/install
-    # - ghpr/get-pr-info:
-    #     get_pr_author_email: true
-    #     get_pr_author_name: true
     - slack/notify:
         custom: |
           {
@@ -140,6 +126,22 @@ jobs:
           path: ./build/cosmos
           destination: cosmos
 
+  release:
+    <<: *job_executor
+    # docker:
+    #   - image: circleci/node
+    # resource_class: small
+    steps:
+      - restore_cache:
+          key: cascara-MONOREPO_INSTALLED-{{ .Revision }}
+      - node/with-cache:
+          steps:
+            - add_ssh_keys:
+                fingerprints:
+                  - $GITHUB_PACKAGE_DEPLOY_FINGERPRINT
+            - run: yarn lerna bootstrap --hoist --ci
+            - run: yarn lerna version --no-private --conventional-commits --create-release github --yes
+
 workflows:
   build-and-test:
     jobs:
@@ -165,3 +167,9 @@ workflows:
           requires:
             - lint
             - test
+      - release:
+          filters:
+            branches:
+              only: main
+          requires:
+            - build-cascara

--- a/lerna.json
+++ b/lerna.json
@@ -17,7 +17,7 @@
     },
     "version": {
       "message": "chore(release): publish",
-      "allowBranch": "main"
+      "allowBranch": ["develop", "main"]
     }
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,15 +2,22 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "version": "independent",
+  "ignoreChanges": [
+    "**/*.fixture.js",
+    "**/*.md",
+    "**/*.mdx",
+    "**/*.test.js",
+    "**/*.test.snap"
+  ],
   "command": {
     "publish": {
-      "ignoreChanges": ["ignored-file", "*.md"],
       "message": "chore(release): publish",
-      "registry": "https://npm.pkg.github.com"
+      "registry": "https://npm.pkg.github.com",
+      "allowBranch": "main"
     },
-    "bootstrap": {
-      "ignore": "component-*",
-      "npmClientArgs": ["--no-package-lock"]
+    "version": {
+      "message": "chore(release): publish",
+      "allowBranch": "main"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "eslint ./",
     "test:watch": "yarn test --watch",
     "test": "jest",
-    "tokens": "style-dictionary build -c ./tokens.config.json"
+    "tokens": "style-dictionary build -c ./tokens.config.json",
+    "publish-packages": "lerna version --amend --conventional-commits --conventional-graduate --no-private --create-release github"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:watch": "yarn test --watch",
     "test": "jest",
     "tokens": "style-dictionary build -c ./tokens.config.json",
-    "publish-packages": "lerna version --amend --conventional-commits --conventional-graduate --no-private --create-release github"
+    "publish-packages": "lerna version --amend --conventional-commits --no-private --create-release github"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This new release step should only run on the `main` branch. I think it is safe to have the docs publish through the Vercel integration since we are basically building the docs on _every_ PR. They might land before the publishing actually happens. It is possible we might want to move the publishing up so that we can use any incremented version numbers to show up in the docs.

### Dependencies

We are updating publish scripts so they can be reused in CircleCI config