### PR TITLE
fix(fds-160): use node instead of element in prop types

### DIFF
--- a/packages/cascara/src/ui/Chat/ChatProvider.js
+++ b/packages/cascara/src/ui/Chat/ChatProvider.js
@@ -64,7 +64,7 @@ const themes = {
 };
 
 const propTypes = {
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   inputComponent: pt.element,
   isThemeSelectable: pt.bool,
 };

--- a/packages/cascara/src/ui/Dashboard/widgets/Widget.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/Widget.js
@@ -11,7 +11,7 @@ const propTypes = {
       content: pt.string,
     })
   ),
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   /** aWidget can have a css class name */
   className: pt.string,
   /** A widget can have a clickable info icon with a description */

--- a/packages/cascara/src/ui/Form/context/FormProvider.js
+++ b/packages/cascara/src/ui/Form/context/FormProvider.js
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { ModuleContext, ModuleProvider } from '../../../modules/context';
 
 const propTypes = {
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   // eslint-disable-next-line react/forbid-prop-types -- We do not know what the object params might be in this case
   value: pt.object,
 };

--- a/packages/cascara/src/ui/Pagination/Pagination.js
+++ b/packages/cascara/src/ui/Pagination/Pagination.js
@@ -11,7 +11,7 @@ const cx = classNames.bind(styles);
 const propTypes = {
   /** Can render as a different tag or component */
   as: pt.oneOfType([pt.string, pt.node]),
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   /** current page */
   currentPage: pt.number,
   /** entity name in plural form */

--- a/packages/cascara/src/ui/Popover/Popover.js
+++ b/packages/cascara/src/ui/Popover/Popover.js
@@ -11,7 +11,7 @@ import styles from './Popover.module.scss';
 import { popperOverTrigger } from '../../shared/popperModifiers';
 
 const propTypes = {
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   trigger: pt.element,
 };
 

--- a/packages/cascara/src/ui/Section/Section.js
+++ b/packages/cascara/src/ui/Section/Section.js
@@ -4,7 +4,7 @@ import pt from 'prop-types';
 import styles from './Section.module.scss';
 
 const propTypes = {
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   footer: pt.string,
   header: pt.string,
 };

--- a/packages/cascara/src/ui/Table/context/RowContext.js
+++ b/packages/cascara/src/ui/Table/context/RowContext.js
@@ -4,7 +4,7 @@ import pt from 'prop-types';
 const TableContext = React.createContext();
 
 const propTypes = {
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   data: pt.arrayOf(pt.shape({})),
   dataConfig: pt.shape({
     actions: pt.arrayOf(pt.shape({})),

--- a/packages/cascara/src/ui/Table/context/RowProvider.js
+++ b/packages/cascara/src/ui/Table/context/RowProvider.js
@@ -4,7 +4,7 @@ import pt from 'prop-types';
 import { ModuleContext, ModuleProvider } from '../../../modules/context';
 
 const propTypes = {
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   value: pt.shape({
     record: pt.shape({}),
   }),

--- a/packages/cascara/src/ui/Table/context/TableContext.js
+++ b/packages/cascara/src/ui/Table/context/TableContext.js
@@ -4,7 +4,7 @@ import pt from 'prop-types';
 const TableContext = React.createContext();
 
 const propTypes = {
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   data: pt.shape({}),
   dataConfig: pt.shape({
     actions: pt.arrayOf(pt.shape({})),

--- a/packages/cascara/src/ui/Table/context/TableProvider.js
+++ b/packages/cascara/src/ui/Table/context/TableProvider.js
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { ModuleContext, ModuleProvider } from '../../../modules/context';
 
 const propTypes = {
-  children: pt.oneOfType([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOfType([pt.node, pt.arrayOf(pt.node)]),
   value: pt.shape({}),
 };
 


### PR DESCRIPTION
Fixes FDS-160

When working on FDS-147, we mistakenly used `element` prop type instead of `node`, which cause lots of warnings in the console.

