### PR TITLE
chore(FDS-179): Dashboard, fix prop type warnings

### DIFF
--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetStatsStat.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetStatsStat.js
@@ -7,8 +7,8 @@ import styles from '../Dashboard.module.scss';
 const propTypes = {
   label: pt.string,
   onClick: pt.func,
-  sub: pt.oneOf([pt.number, pt.string]),
-  value: pt.oneOf([pt.number, pt.string]),
+  sub: pt.oneOfType([pt.number, pt.string]),
+  value: pt.oneOfType([pt.number, pt.string]),
 };
 
 const WidgetStatsStat = ({ onClick, label, value, sub }) => {


### PR DESCRIPTION
Resolves [FDS-179](https://espressive.atlassian.net/browse/FDS-179).

We made a mistake when setting prop types for `WidgetStatsStat`, we used `oneOf` isntead of `oneOfType`.