### PR TITLE
Chore/fds-206 remove design tokens as peer-dependency from Cascara

### DIFF
--- a/packages/cascara/package.json
+++ b/packages/cascara/package.json
@@ -50,7 +50,6 @@
     "prop-types": "15.7.2"
   },
   "peerDependencies": {
-    "@espressive/design-tokens": "*",
     "@fluentui/react-northstar": ">=0.52.0",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",


### PR DESCRIPTION
Resolves FDS-206.

### Dependencies
Design tokens was listed as `peer-dependency` for `Cascara`, which is incorrect. This PR removes such dependency.