### PR TITLE
chore(FDS-253): separate out all of the elements of dataConfig and get rid of it

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,8 +56,14 @@
     "sideBarSectionHeader.background": "#90023A",
     "sideBarSectionHeader.foreground": "#e7e7e7"
   },
-  "peacock.color": "#850c37",
   "files.associations": {
     "*.yaml": "home-assistant"
-  }
+  },
+  "jest.coverageColors": {
+    "covered": "rgba(9, 156, 65, 1)",
+    "uncovered": "rgba(0, 0, 0, 1)",
+    "partially-covered": "rgba(235, 198, 52, 1)"
+  },
+  "jest.jestCommandLine": "yarn test",
+  "jest.showCoverageOnLoad": true
 }

--- a/packages/cascara/src/index.js
+++ b/packages/cascara/src/index.js
@@ -11,7 +11,7 @@ import JsonPlaceholder from './placeholders/JsonPlaceholder';
 import Button from './ui/Button';
 import Chat from './ui/Chat';
 import Dashboard from './ui/Dashboard';
-// import Form , { propTypes as formPropTypes } from './ui/Form';
+import Form, { propTypes as formPropTypes } from './ui/Form';
 import Table, { propTypes as tablePropTypes } from './ui/Table';
 
 export {
@@ -22,8 +22,8 @@ export {
   BaristaStructure,
   Chat,
   Dashboard,
-  // Form,
-  // formPropTypes,
+  Form,
+  formPropTypes,
   JsonPlaceholder,
   Table,
   tablePropTypes,

--- a/packages/cascara/src/modules/ActionButton/ActionButton.js
+++ b/packages/cascara/src/modules/ActionButton/ActionButton.js
@@ -17,12 +17,7 @@ const propTypes = {
   name: pt.string,
 };
 
-const ActionButton = ({
-  actionName,
-  content = 'ActionButton',
-  isLabeled = false,
-  ...rest
-}) => {
+const ActionButton = ({ actionName, content, isLabeled = false, ...rest }) => {
   const { isEditing, onAction, record } = useContext(ModuleContext);
 
   // @bje we need to decide if we go for content or label here, both makes no sense
@@ -52,6 +47,7 @@ const ActionButton = ({
   return isEditing ? null : (
     <Button
       {...restWithoutLabel}
+      aria-label={label}
       className='ui basic button'
       name={name}
       onClick={handleClick}

--- a/packages/cascara/src/ui/Form/Form.test.js
+++ b/packages/cascara/src/ui/Form/Form.test.js
@@ -15,7 +15,7 @@ describe('Form', () => {
     country: faker.address.countryCode(),
     date: safeDate,
     department: faker.name.jobArea(),
-    eid: faker.random.uuid(),
+    eid: faker.datatype.uuid(),
     firstName: faker.name.firstName(),
     homePhone: faker.phone.phoneNumber(),
     lastName: faker.name.lastName(),
@@ -23,98 +23,92 @@ describe('Form', () => {
     title: faker.name.jobTitle(),
   };
 
-  const dataConfig = {
-    actions: [
+  const actions = {
+    modules: [
       {
-        cancelLabel: 'Cancelar',
-        dataTestIDs: {
-          cancel: 'cancelButton',
-          edit: 'editButton',
-          save: 'saveButton',
-        },
-        editLabel: 'Editar',
         module: 'edit',
-        saveLabel: 'Guardar',
       },
       {
-        actionName: 'delete',
-        'data-testid': 'deleteButton',
         isLabeled: false,
         label: 'Delete',
         module: 'button',
+        name: 'delete',
         size: 'small',
       },
     ],
-    display: [
-      {
-        attribute: 'eid',
-        label: 'EID',
-        module: 'text',
-      },
-      {
-        fields: [
-          {
-            attribute: 'firstName',
-            label: 'First Name',
-            module: 'text',
-          },
-          {
-            attribute: 'lastName',
-            label: 'Last Name',
-            module: 'text',
-          },
-          {
-            attribute: 'officePhone',
-            label: 'Office Phone',
-            module: 'text',
-          },
-        ],
-        module: 'row',
-        ratio: [1, 1, 2],
-      },
-      {
-        attribute: 'homePhone',
-        label: 'Home Phone',
-        module: 'text',
-      },
-      {
-        fields: [
-          {
-            attribute: 'title',
-            isEditable: false,
-            label: 'Title',
-            module: 'text',
-          },
-          {
-            attribute: 'department',
-            isEditable: false,
-            label: 'Department',
-            module: 'text',
-          },
-          {
-            attribute: 'country',
-            isEditable: false,
-            label: 'Country',
-            module: 'text',
-          },
-        ],
-        module: 'row',
-      },
-    ],
   };
+
+  const dataDisplay = [
+    {
+      attribute: 'eid',
+      label: 'EID',
+      module: 'text',
+    },
+    {
+      fields: [
+        {
+          attribute: 'firstName',
+          label: 'First Name',
+          module: 'text',
+        },
+        {
+          attribute: 'lastName',
+          label: 'Last Name',
+          module: 'text',
+        },
+        {
+          attribute: 'officePhone',
+          label: 'Office Phone',
+          module: 'text',
+        },
+      ],
+      module: 'row',
+      ratio: [1, 1, 2],
+    },
+    {
+      attribute: 'homePhone',
+      label: 'Home Phone',
+      module: 'text',
+    },
+    {
+      fields: [
+        {
+          attribute: 'title',
+          isEditable: false,
+          label: 'Title',
+          module: 'text',
+        },
+        {
+          attribute: 'department',
+          isEditable: false,
+          label: 'Department',
+          module: 'text',
+        },
+        {
+          attribute: 'country',
+          isEditable: false,
+          label: 'Country',
+          module: 'text',
+        },
+      ],
+      module: 'row',
+    },
+  ];
 
   let view;
 
   beforeAll(() => {});
 
   test('snapshot test', () => {
-    view = render(<Form data={data} dataConfig={dataConfig} />).container;
+    view = render(
+      <Form actions={actions} data={data} dataDisplay={dataDisplay} />
+    ).container;
 
     expect(view).toMatchSnapshot();
   });
 
   test('component tree', async () => {
-    render(<Form data={data} dataConfig={dataConfig} />);
+    render(<Form actions={actions} data={data} dataDisplay={dataDisplay} />);
 
     const eid = await screen.findByText('EID');
     const firstName = await screen.findByText('First Name');
@@ -125,8 +119,8 @@ describe('Form', () => {
     const department = await screen.findByText('Department');
     const country = await screen.findByText('Country');
 
-    const editButton = await screen.findByTestId('editButton');
-    const deleteButton = await screen.findByTestId('deleteButton');
+    const editButton = await screen.findByRole('button', { name: 'Edit' });
+    const deleteButton = await screen.findByRole('button', { name: 'Delete' });
 
     expect(eid).toBeInTheDocument();
     expect(firstName).toBeInTheDocument();
@@ -142,39 +136,48 @@ describe('Form', () => {
   });
 
   test('it starts in edit mode when isInitialEditing is true', async () => {
-    render(<Form data={data} dataConfig={dataConfig} isInitialEditing />);
+    render(
+      <Form
+        actions={actions}
+        data={data}
+        dataDisplay={dataDisplay}
+        isInitialEditing
+      />
+    );
 
-    const cancelButton = await screen.findByTestId('cancelButton');
-    const saveButton = await screen.findByTestId('saveButton');
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+    const saveButton = await screen.findByRole('button', { name: 'Save' });
 
     expect(cancelButton).toBeInTheDocument();
     expect(saveButton).toBeInTheDocument();
 
-    const editButton = screen.queryByTestId('editButton');
+    const editButton = screen.queryByRole('button', { name: 'Edit' });
     expect(editButton).not.toBeInTheDocument();
   });
 
   test('general flow: View Mode -> Edit Mode -> Save Action -> View Mode', async () => {
     const onAction = jest.fn();
 
-    render(<Form data={data} dataConfig={dataConfig} onAction={onAction} />);
+    render(
+      <Form
+        actions={actions}
+        data={data}
+        dataDisplay={dataDisplay}
+        onAction={onAction}
+      />
+    );
 
     // make sure we are in view mode
-    let cancelButton = screen.queryByTestId('cancelButton');
-    let saveButton = screen.queryByTestId('saveButton');
-    let editButton = screen.queryByTestId('editButton');
-
-    expect(cancelButton).not.toBeInTheDocument();
-    expect(saveButton).not.toBeInTheDocument();
+    let editButton = await screen.findByRole('button', { name: 'Edit' });
     expect(editButton).toBeInTheDocument();
 
     // enter edit mode
     userEvent.click(editButton);
 
     // make sure we are in edit mode
-    cancelButton = await screen.findByTestId('cancelButton');
-    saveButton = await screen.findByTestId('saveButton');
-    editButton = screen.queryByTestId('editButton');
+    let cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+    let saveButton = await screen.findByRole('button', { name: 'Save' });
+    editButton = screen.queryByRole('button', { name: 'Edit' });
 
     expect(cancelButton).toBeInTheDocument();
     expect(saveButton).toBeInTheDocument();
@@ -189,16 +192,16 @@ describe('Form', () => {
 
     userEvent.type(firstName, 'nio');
 
-    saveButton = await screen.findByTestId('saveButton');
+    saveButton = screen.queryByRole('button', { name: 'Save' });
     expect(saveButton).not.toBeDisabled();
 
     // Save action
     userEvent.click(saveButton);
 
     // make sure we are back to view mode
-    editButton = await screen.findByTestId('editButton');
-    cancelButton = screen.queryByTestId('cancelButton');
-    saveButton = screen.queryByTestId('saveButton');
+    saveButton = await screen.findByRole('button', { name: 'Save' });
+    editButton = screen.queryByRole('button', { name: 'Edit' });
+    cancelButton = screen.queryByRole('button', { name: 'Cancel' });
 
     expect(cancelButton).not.toBeInTheDocument();
     expect(saveButton).not.toBeInTheDocument();
@@ -229,11 +232,18 @@ describe('Form', () => {
   test('onAction events', async () => {
     const onAction = jest.fn();
 
-    render(<Form data={data} dataConfig={dataConfig} onAction={onAction} />);
+    render(
+      <Form
+        actions={actions}
+        data={data}
+        dataDisplay={dataDisplay}
+        onAction={onAction}
+      />
+    );
 
     // verify buttons are there
-    const deleteButton = screen.queryByTestId('deleteButton');
-    const editButton = screen.queryByTestId('editButton');
+    const deleteButton = await screen.findByRole('button', { name: 'Delete' });
+    const editButton = await screen.findByRole('button', { name: 'Edit' });
 
     expect(deleteButton).toBeInTheDocument();
     expect(editButton).toBeInTheDocument();

--- a/packages/cascara/src/ui/Form/Form.test.snap
+++ b/packages/cascara/src/ui/Form/Form.test.snap
@@ -147,19 +147,19 @@ exports[`Form snapshot test 1`] = `
       class="FormActionBar"
     >
       <button
+        aria-label="Edit"
         class="ui basic button"
-        data-testid="editButton"
         type="button"
       >
-        Editar
+        Edit
       </button>
       <button
+        aria-label="Delete"
         class="ui basic button"
-        data-testid="deleteButton"
         name="delete"
         type="button"
       >
-        ActionButton
+        Delete
       </button>
     </div>
   </form>

--- a/packages/cascara/src/ui/Form/modules/ActionEdit/ActionEdit.js
+++ b/packages/cascara/src/ui/Form/modules/ActionEdit/ActionEdit.js
@@ -7,16 +7,15 @@ import { Icon } from 'semantic-ui-react';
 
 const propTypes = {
   cancelLabel: pt.string,
-  dataTestIDs: pt.shape({
-    cancel: pt.string,
-    edit: pt.string,
-    save: pt.string,
-  }),
   editLabel: pt.string,
   saveLabel: pt.string,
 };
 
-const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
+const ActionEdit = ({
+  cancelLabel = 'Cancel',
+  editLabel = 'Edit',
+  saveLabel = 'Save',
+}) => {
   const {
     isEditing,
     enterEditMode,
@@ -27,18 +26,6 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
   } = useContext(ModuleContext);
   const { handleSubmit, formState, reset } = formMethods;
   const { isDirty, isSubmitting } = formState;
-
-  // this seems like ugly, we need to find a better way
-  // to ease testing..
-  const cancelTestId = {};
-  const editTestId = {};
-  const saveTestId = {};
-
-  if (typeof dataTestIDs === 'object') {
-    cancelTestId['data-testid'] = dataTestIDs['cancel'];
-    editTestId['data-testid'] = dataTestIDs['edit'];
-    saveTestId['data-testid'] = dataTestIDs['save'];
-  }
 
   const handleReset = useCallback(() => {
     onAction(
@@ -99,7 +86,7 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
   return isEditing ? (
     <>
       <Button
-        {...cancelTestId}
+        aria-label={cancelLabel}
         className='ui negative icon button'
         disabled={isSubmitting}
         onClick={handleCancel}
@@ -108,7 +95,7 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
         <Icon name='delete' />
       </Button>
       <Button
-        {...saveTestId}
+        aria-label={saveLabel}
         className='ui positive icon button'
         disabled={!isDirty || isSubmitting}
         onClick={handleSubmit(onSubmit)}
@@ -119,7 +106,7 @@ const ActionEdit = ({ dataTestIDs, editLabel = 'Edit' }) => {
     </>
   ) : (
     <Button
-      {...editTestId}
+      aria-label={editLabel}
       className='ui basic button'
       onClick={handleEdit}
       type='button'

--- a/packages/cascara/src/ui/Form/modules/FormRow/FormRow.js
+++ b/packages/cascara/src/ui/Form/modules/FormRow/FormRow.js
@@ -5,7 +5,7 @@ import styles from '../../Form.module.scss';
 import ErrorBoundary from '../../../../shared/ErrorBoundary';
 
 const propTypes = {
-  children: pt.oneOf([pt.element, pt.arrayOf(pt.element)]),
+  children: pt.oneOf([pt.node, pt.arrayOf(pt.node)]),
   ratio: pt.arrayOf(pt.oneOfType([pt.number, pt.string])),
 };
 

--- a/packages/cascara/src/ui/Form/poc/Form.fixture.js
+++ b/packages/cascara/src/ui/Form/poc/Form.fixture.js
@@ -18,8 +18,8 @@ const data = {
   title: faker.name.jobTitle(),
 };
 
-const dataConfig = {
-  actions: [
+const actions = {
+  modules: [
     {
       module: 'edit',
     },
@@ -34,57 +34,58 @@ const dataConfig = {
       module: 'button',
     },
   ],
-  display: [
-    {
-      attribute: 'eid',
-      label: 'EID',
-      module: 'text',
-    },
-    {
-      fields: [
-        {
-          attribute: 'firstName',
-          label: 'First Name',
-          module: 'text',
-        },
-        {
-          attribute: 'lastName',
-          label: 'Last Name',
-          module: 'text',
-        },
-      ],
-      module: 'row',
-    },
-    {
-      attribute: 'homePhone',
-      label: 'Home Phone',
-      module: 'text',
-    },
-    {
-      fields: [
-        {
-          attribute: 'title',
-          isEditable: false,
-          label: 'Title',
-          module: 'text',
-        },
-        {
-          attribute: 'department',
-          isEditable: false,
-          label: 'Department',
-          module: 'text',
-        },
-        {
-          attribute: 'country',
-          isEditable: false,
-          label: 'Country',
-          module: 'text',
-        },
-      ],
-      module: 'row',
-    },
-  ],
 };
+
+const dataDisplay = [
+  {
+    attribute: 'eid',
+    label: 'EID',
+    module: 'text',
+  },
+  {
+    fields: [
+      {
+        attribute: 'firstName',
+        label: 'First Name',
+        module: 'text',
+      },
+      {
+        attribute: 'lastName',
+        label: 'Last Name',
+        module: 'text',
+      },
+    ],
+    module: 'row',
+  },
+  {
+    attribute: 'homePhone',
+    label: 'Home Phone',
+    module: 'text',
+  },
+  {
+    fields: [
+      {
+        attribute: 'title',
+        isEditable: false,
+        label: 'Title',
+        module: 'text',
+      },
+      {
+        attribute: 'department',
+        isEditable: false,
+        label: 'Department',
+        module: 'text',
+      },
+      {
+        attribute: 'country',
+        isEditable: false,
+        label: 'Country',
+        module: 'text',
+      },
+    ],
+    module: 'row',
+  },
+];
 
 const BasicForm = (props) => {
   const handleFormAction = useCallback((action, data) => {
@@ -129,8 +130,13 @@ const InitialEditing = (props) => (
 );
 
 export default {
-  basic: <BasicForm data={data} dataConfig={dataConfig} />,
+  basic: <BasicForm actions={actions} data={data} dataDisplay={dataDisplay} />,
   initialEditing: (
-    <InitialEditing data={data} dataConfig={dataConfig} isInitialEditing />
+    <InitialEditing
+      actions={actions}
+      data={data}
+      dataDisplay={dataDisplay}
+      isInitialEditing
+    />
   ),
 };

--- a/packages/cascara/src/ui/Table/ActionBar.test.snap
+++ b/packages/cascara/src/ui/Table/ActionBar.test.snap
@@ -13,20 +13,22 @@ exports[`ActionBar component tree snapshot 1`] = `
     Espressive
   </span>
   <button
+    aria-label="new"
     class="ui basic button"
     data-testid="new"
     name="new"
     type="button"
   >
-    ActionButton
+    new
   </button>
   <button
+    aria-label="edit"
     class="ui basic button"
     data-testid="edit"
     name="edit"
     type="button"
   >
-    ActionButton
+    edit
   </button>
 </div>
 `;

--- a/packages/cascara/src/ui/Table/Table.test.snap
+++ b/packages/cascara/src/ui/Table/Table.test.snap
@@ -211,22 +211,7 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -387,22 +372,7 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -564,22 +534,7 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -741,22 +696,7 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -918,22 +858,7 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -1094,22 +1019,7 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -1343,22 +1253,7 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -1519,22 +1414,7 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -1696,22 +1576,7 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -1873,22 +1738,7 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -2050,22 +1900,7 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"
@@ -2226,22 +2061,7 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            >
-              <svg
-                focusable="false"
-                height="1em"
-                preserveAspectRatio="xMidYMid meet"
-                style="transform: rotate(360deg); vertical-align: -0.143em;"
-                viewBox="0 0 140 140"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            />
             <button
               class="ui basic button"
               name="view"

--- a/packages/cascara/src/ui/Table/Table.test.snap
+++ b/packages/cascara/src/ui/Table/Table.test.snap
@@ -211,7 +211,22 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -372,7 +387,22 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -534,7 +564,22 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -696,7 +741,22 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -858,7 +918,22 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -1019,7 +1094,22 @@ exports[`Table component tree snapshot test 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -1253,7 +1343,22 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -1414,7 +1519,22 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -1576,7 +1696,22 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -1738,7 +1873,22 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -1900,7 +2050,22 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"
@@ -2061,7 +2226,22 @@ exports[`Table component tree without row actions 1`] = `
               class="ui basic icon button"
               name="edit.start"
               type="button"
-            />
+            >
+              <svg
+                focusable="false"
+                height="1em"
+                preserveAspectRatio="xMidYMid meet"
+                style="transform: rotate(360deg); vertical-align: -0.143em;"
+                viewBox="0 0 140 140"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M87.89 23.252a2.917 2.917 0 0 0-2.064-.864a2.917 2.917 0 0 0-2.065.858L20.049 86.975a2.917 2.917 0 0 0 0 4.124l28.863 28.863a2.917 2.917 0 0 0 4.125 0l63.682-63.682a2.917 2.917 0 0 0 0-4.118zM14.175 98a2.917 2.917 0 0 0-2.852-.74a2.917 2.917 0 0 0-2.048 2.123L.49 135.998a2.917 2.917 0 0 0 .776 2.742a2.958 2.958 0 0 0 2.742.77l36.586-8.75a2.917 2.917 0 0 0 1.383-4.9zm121.158-80.943L122.95 4.667a14.583 14.583 0 0 0-20.603 0l-8.272 8.265a2.917 2.917 0 0 0 0 4.125l28.875 28.869a2.917 2.917 0 0 0 4.124 0l8.26-8.278a14.583 14.583 0 0 0 0-20.591z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
             <button
               class="ui basic button"
               name="view"


### PR DESCRIPTION
Resolves FDS-253.

We are moving towards a clean set of props that can be used interchangeably between `Form` and `Table`.
Old props are stripped away and new props are defined and wired-up.

### Dependencies
Index of Cascara was updated to include propTypes exports.

### Fixtures
Form fixture has been updated to include new props.

### Snapshots
The changes in props, plus the fact that we are defining `arial-labels` for `Action` buttons has caused fixtures to change.