### PR TITLE
bugfix(FDS-279)  Make sure empty class only present for empty or loading widgets

### DIFF
--- a/packages/cascara/src/ui/Dashboard/DashboardDX.fixture.js
+++ b/packages/cascara/src/ui/Dashboard/DashboardDX.fixture.js
@@ -1,93 +1,93 @@
 import React from 'react';
 import Dashboard from './Dashboard';
+import pieData from './data/Pie';
+import geoMapData from './data/GeoMap';
+import barData from './data/Bar';
 
+const statsData = [
+  {
+    label: 'Total Interactions',
+    onClick: () => alert('hi'),
+    value: '12,535',
+  },
+  {
+    label: 'Unique Users',
+    value: '1,205',
+  },
+  {
+    label: 'On Mobile',
+    sub: 'Interactions via Barista Channel',
+    value: '58%',
+  },
+];
+
+const WIDGET_DATA = {
+  bar: barData,
+  bubble: geoMapData,
+  'geo-map': geoMapData,
+  list: barData,
+  pie: pieData,
+  stats: statsData,
+};
+
+// Widgets here are defined in alphabetical order except for the duplicate Stats widget we are defining at top
 const WIDGETS = [
-  {
-    data: undefined,
-    keys: ['country', 'fries', 'curry'], // Without keys defined, all data from each object will show
-    // rowAction: (obj) => console.log(obj), // Without a rowAction defined, no row action will show. Note that the function gets the original object passed to it.
-    title: 'List',
-    widget: 'list',
-  },
-  {
-    data: null,
-    indexBy: 'id', // 'id' is the default and not needed if the data already matches
-    label: 'value', // 'value' is the default and is not needed if the data already matches
-    title: 'Bubble',
-    widget: 'bubble',
-  },
   {
     actions: [
       {
         content: 'view',
       },
     ],
-    title: 'Interactions',
-    widget: 'stats',
-  },
-  {
-    data: undefined,
-    title: 'Deflections',
+    description:
+      'Your most frequently matched intents in the time period selected.',
+    title: 'w/ Actions & Description',
     widget: 'stats',
   },
   {
     axisBottomLabel: 'Month',
     axisLeftLabel: 'Requests',
     data: null,
-    description:
-      'Shows number of requests and how your users have rated their experience over time',
     indexBy: 'month',
     keys: ['helpful', 'not helpful', 'no data'],
-    title: 'User Feedback',
+    title: 'Bar',
     widget: 'bar',
   },
   {
-    title: 'Interactions by Country',
+    data: null,
+    title: 'Bubble',
+    widget: 'bubble',
+  },
+  {
+    title: 'Geo Map',
     widget: 'geo-map',
   },
   {
-    axisLeft: null,
-    description:
-      'Questions that your users are asking that correspond to non-configured FAQ articles.',
-    indexBy: 'label',
-    layout: 'horizontal',
-    title: 'Top 10 Unanswered Questions',
-    widget: 'bar',
-  },
-  {
-    description:
-      'Your most frequently matched intents in the time period selected.',
-    enableRadialLabels: false,
-    title: 'Top Matched Intents',
-    widget: 'pie',
-  },
-  {
-    axisBottomLabel: 'Month',
-    axisLeftLabel: 'Count',
-    indexBy: 'month',
-    keys: ['Deflected', 'Not Deflected'],
-    title: 'Deflected VS Not Deflected',
-    widget: 'bar',
+    data: undefined,
+    // keys: ['country', 'fries', 'curry'],
+    // rowAction: (obj) => console.log(obj), // Without a rowAction defined, no row action will show. Note that the function gets the original object passed to it.
+    title: 'List',
+    widget: 'list',
   },
   {
     enableRadialLabels: false,
-    title: 'Channels',
+    title: 'Pie',
     widget: 'pie',
   },
   {
-    axisBottomLabel: 'Requests',
-    axisLeftLabel: 'Operating System',
-    description:
-      'Breakdown of interactions via Barista channel by operating system and client',
-    indexBy: 'OS',
-    keys: ['Safari', 'Chrome', 'Native App', 'Edge', 'Other'],
-    layout: 'horizontal',
-    title: 'Barista Channel Interactions by OS/Client',
-    widget: 'bar',
+    data: undefined,
+    title: 'Stats',
+    widget: 'stats',
   },
 ];
 
+// Adds an empty array to data for all widgets
 const EMPTY_WIDGETS = WIDGETS.map((obj) => ({ ...obj, data: [] }));
+
+// Adds data to the widgets to render
+const DATA_WIDGETS = WIDGETS.map((obj) => ({
+  ...obj,
+  data: WIDGET_DATA?.[obj.widget] || [],
+}));
 
 const NoProps = (fixtureProps) => (
   <>
@@ -125,15 +125,23 @@ const Empty = (fixtureProps) => (
   </>
 );
 
-// We export the data results here for use in our tests.
-// This also allows us to generate test data from inside a fixture and then reuse it in tests.
-// const dataResults = results;
-// export { dataResults };
+const WithData = (fixtureProps) => (
+  <>
+    <h3>With Data</h3>
+    <p>
+      When adding data to all widgets to display, we want to validate none of
+      the above fixtures broke anything.
+    </p>
+
+    <Dashboard {...fixtureProps} />
+  </>
+);
 
 /* eslint-disable sort-keys -- We want these to show in a specific order in the UI */
 export default {
   noProps: <NoProps />,
   loading: <Loading config={WIDGETS} />,
   empty: <Empty config={EMPTY_WIDGETS} />,
+  withData: <WithData config={DATA_WIDGETS} />,
 };
 /* eslint-enable sort-keys */

--- a/packages/cascara/src/ui/Dashboard/widgets/Widget.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/Widget.js
@@ -4,7 +4,6 @@ import pt from 'prop-types';
 import InfoPopover from '../../InfoPopover';
 import { Button } from 'reakit';
 import styles from '../Dashboard.module.scss';
-import { getDataState } from './dataState';
 
 const cx = classnames.bind(styles);
 
@@ -22,6 +21,10 @@ const propTypes = {
   description: pt.string,
   /** The height of a widget */
   height: pt.oneOfType([pt.number, pt.oneOf(['auto'])]),
+  // A widget can be in an empty state
+  isEmpty: pt.bool,
+  // A widget can be in a loading state
+  isLoading: pt.bool,
   /** A widget can contain scrolling content */
   isScrolling: pt.bool,
   /** A widget can display with a title */
@@ -37,12 +40,12 @@ const Widget = ({
   className,
   description,
   height = 400,
+  isEmpty = false,
+  isLoading = false,
   isScrolling = false,
   title,
   ...rest
 }) => {
-  const { isLoading, isEmpty } = getDataState(rest.data);
-
   return (
     <div
       className={cx(className, {
@@ -66,11 +69,17 @@ const Widget = ({
       <div
         className={cx(className, {
           Data: true,
-          'no-data': isLoading || isEmpty,
+          'no-data': isEmpty || isLoading,
         })}
         style={{ height: height }}
       >
-        {Children.map(children, (child) => cloneElement(child, { ...rest }))}
+        {isLoading ? (
+          <div className='ui active centered inline loader' />
+        ) : isEmpty ? (
+          <em>No data.</em>
+        ) : (
+          Children.map(children, (child) => cloneElement(child, { ...rest }))
+        )}
       </div>
     </div>
   );

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetBar.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetBar.js
@@ -62,25 +62,19 @@ const WidgetBar = ({
     },
   };
 
-  const { isLoading, isEmpty } = getDataState(data);
+  const dataState = getDataState(data);
 
   return (
-    <Widget {...rest}>
-      {isLoading ? (
-        <div className='ui active centered inline loader' />
-      ) : isEmpty ? (
-        <em>No data.</em>
-      ) : (
-        <ResponsiveBar
-          {...CHART_CONFIG}
-          axisLeft={axisLeft}
-          data={data}
-          indexBy={indexBy}
-          keys={keys}
-          label={label}
-          layout={layout}
-        />
-      )}
+    <Widget {...rest} {...dataState}>
+      <ResponsiveBar
+        {...CHART_CONFIG}
+        axisLeft={axisLeft}
+        data={data}
+        indexBy={indexBy}
+        keys={keys}
+        label={label}
+        layout={layout}
+      />
     </Widget>
   );
 };

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetBubble.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetBubble.js
@@ -28,22 +28,16 @@ const WidgetBubble = ({ data, indexBy = 'id', label = 'value', ...rest }) => {
     padding: 6,
   };
 
-  const { isLoading, isEmpty } = getDataState(data);
+  const dataState = getDataState(data);
 
   return (
-    <Widget {...rest}>
-      {isLoading ? (
-        <div className='ui active centered inline loader' />
-      ) : isEmpty ? (
-        <em>No data.</em>
-      ) : (
-        <ResponsiveBubble
-          {...CHART_CONFIG}
-          identity={indexBy}
-          root={{ children: data, id: '' }}
-          value={label}
-        />
-      )}
+    <Widget {...rest} {...dataState}>
+      <ResponsiveBubble
+        {...CHART_CONFIG}
+        identity={indexBy}
+        root={{ children: data, id: '' }}
+        value={label}
+      />
     </Widget>
   );
 };

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetGeoMap.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetGeoMap.js
@@ -32,21 +32,15 @@ const WidgetGeoMap = ({ data, ...rest }) => {
     unknownColor: 'rgba(0,0,0,.05)',
   };
 
-  const { isLoading, isEmpty } = getDataState(data);
+  const dataState = getDataState(data);
 
   return (
-    <Widget {...rest} height={320}>
-      {isLoading ? (
-        <div className='ui active centered inline loader' />
-      ) : isEmpty ? (
-        <em>No data.</em>
-      ) : (
-        <ResponsiveChoroplethCanvas
-          {...CHART_CONFIG}
-          data={data}
-          features={GeoMapFeatures.features}
-        />
-      )}
+    <Widget {...rest} {...dataState} height={320}>
+      <ResponsiveChoroplethCanvas
+        {...CHART_CONFIG}
+        data={data}
+        features={GeoMapFeatures.features}
+      />
     </Widget>
   );
 };

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetHeatMap.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetHeatMap.js
@@ -16,33 +16,27 @@ const propTypes = {
  * Widget for @nivo/heatmap.
  */
 const WidgetHeatMap = ({ data, indexBy = 'id', ...rest }) => {
-  const { isLoading, isEmpty } = getDataState(data);
+  const dataState = getDataState(data);
 
   return (
-    <Widget {...rest}>
-      {isLoading ? (
-        <div className='ui active centered inline loader' />
-      ) : isEmpty ? (
-        <em>No data.</em>
-      ) : (
-        <ResponsiveHeatMapCanvas
-          data={data}
-          indexBy={indexBy}
-          keys={[
-            'hot dog',
-            'burger',
-            'sandwich',
-            'kebab',
-            'fries',
-            'donut',
-            'junk',
-            'sushi',
-            'ramen',
-            'curry',
-            'udon',
-          ]}
-        />
-      )}
+    <Widget {...rest} {...dataState}>
+      <ResponsiveHeatMapCanvas
+        data={data}
+        indexBy={indexBy}
+        keys={[
+          'hot dog',
+          'burger',
+          'sandwich',
+          'kebab',
+          'fries',
+          'donut',
+          'junk',
+          'sushi',
+          'ramen',
+          'curry',
+          'udon',
+        ]}
+      />
     </Widget>
   );
 };

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetLine.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetLine.js
@@ -47,17 +47,11 @@ const WidgetLine = ({ axisBottomLabel, axisLeftLabel, data, ...rest }) => {
     },
   };
 
-  const { isLoading, isEmpty } = getDataState(data);
+  const dataState = getDataState(data);
 
   return (
-    <Widget {...rest}>
-      {isLoading ? (
-        <div className='ui active centered inline loader' />
-      ) : isEmpty ? (
-        <em>No data.</em>
-      ) : (
-        <ResponsiveLine {...CHART_CONFIG} data={data} />
-      )}
+    <Widget {...rest} {...dataState}>
+      <ResponsiveLine {...CHART_CONFIG} data={data} />
     </Widget>
   );
 };

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetList.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetList.js
@@ -14,13 +14,8 @@ const propTypes = {
   rowAction: pt.func,
 };
 
-/**
- * Widget for displaying list data.
- */
-const WidgetList = ({ data, keys, rowAction, ...rest }) => {
-  const { isLoading, isEmpty } = getDataState(data);
-
-  const preparedData = keys
+const getPreparedData = (keys, data) =>
+  keys
     ? data?.map((obj) =>
         Object.fromEntries(
           Object.entries(obj).filter(([key]) => keys.includes(key))
@@ -28,13 +23,18 @@ const WidgetList = ({ data, keys, rowAction, ...rest }) => {
       )
     : data;
 
+/**
+ * Widget for displaying list data.
+ */
+const WidgetList = ({ data, keys, rowAction, ...rest }) => {
+  const dataState = getDataState(data);
+  const { isEmpty, isLoading } = dataState;
+
+  const preparedData = getPreparedData(keys, data);
+
   return (
-    <Widget {...rest} isScrolling>
-      {isLoading ? (
-        <div className='ui active centered inline loader' />
-      ) : isEmpty ? (
-        <em>No data.</em>
-      ) : (
+    <Widget {...rest} {...dataState} isScrolling>
+      {!isLoading && !isEmpty && (
         <table>
           <thead>
             <tr>

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetPie.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetPie.js
@@ -29,17 +29,11 @@ const CHART_CONFIG = {
  * Widget for @nivo/pie.
  */
 const WidgetPie = ({ data, ...rest }) => {
-  const { isLoading, isEmpty } = getDataState(data);
+  const dataState = getDataState(data);
 
   return (
-    <Widget {...rest}>
-      {isLoading ? (
-        <div className='ui active centered inline loader' />
-      ) : isEmpty ? (
-        <em>No data.</em>
-      ) : (
-        <ResponsivePie {...CHART_CONFIG} data={data} />
-      )}
+    <Widget {...rest} {...dataState}>
+      <ResponsivePie {...CHART_CONFIG} data={data} />
     </Widget>
   );
 };

--- a/packages/cascara/src/ui/Dashboard/widgets/WidgetStats.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/WidgetStats.js
@@ -15,17 +15,13 @@ const propTypes = {
  * Widget for displaying stats
  */
 const WidgetStats = ({ data, ...rest }) => {
-  const { isLoading, isEmpty } = getDataState(data);
+  const dataState = getDataState(data);
 
   return (
-    <Widget {...rest} className={styles.Stats} height='auto'>
-      {isLoading ? (
-        <div className='ui active centered inline loader' />
-      ) : isEmpty ? (
-        <em>No data.</em>
-      ) : (
-        data?.map((stat) => <Stat {...stat} key={stat.label} />)
-      )}
+    <Widget {...rest} {...dataState} className={styles.Stats} height='auto'>
+      {data?.map((stat) => (
+        <Stat {...stat} key={stat.label} />
+      ))}
     </Widget>
   );
 };

--- a/packages/cascara/src/ui/Dashboard/widgets/dataState.js
+++ b/packages/cascara/src/ui/Dashboard/widgets/dataState.js
@@ -2,7 +2,7 @@ import pt from 'prop-types';
 
 const getDataState = (data) => {
   // If data is not defined, we are in a loading state
-  const isLoading = data === undefined || data === null;
+  const isLoading = Boolean(data === undefined) || Boolean(data === null);
   // If data is defined but it is explicitly empty, we are in an empty state
   const isEmpty = !isLoading && data.length === 0;
 


### PR DESCRIPTION
This also cleans up the logic for when to display a component or not into the widget itself where we decide if we should even render children


