### PR TITLE
Fix TableBase: uniqueIdAttribute is incorrectly set to undefined by a faulty check

### DIFF
--- a/packages/cascara/src/ui/Table/0-Table.mdx
+++ b/packages/cascara/src/ui/Table/0-Table.mdx
@@ -215,6 +215,16 @@ const onAction = (action, record) => {
 
 Specifies the attribute that uniquely identifies every object in the **data** array.
 
+> It is always recommended to speficy `uniqueIdAttribute`. Although it can be derived from the data itself, the inference function defines the following as possible values:
+>
+> - eid
+> - uuid
+> - id
+> - sys_date_created
+> - number
+>
+> If you see a warning like 'Each child in a list should have a unique "key" prop' from Table, please make sure you pass this prop to prevent Table's **auto-id-inference** from kicking-in and **possibly** infering **undefined** if the data you pass does not have any of the possible values.
+
 # Mixing everyting together
 
 With the four props described earlier, we can easily create a table: (open your dev tools!)

--- a/packages/cascara/src/ui/Table/TableBase.js
+++ b/packages/cascara/src/ui/Table/TableBase.js
@@ -7,7 +7,9 @@ import TableProvider from './context/TableProvider';
 import TableHeader from './TableHeader';
 import TableBody from './TableBody';
 
-const UUID_PRIORITY_KEYS = ['eid', 'uuid', 'id', 'sys_date_created'];
+// [fix] FDS-284: uniqueIdAttribute is always derived as undefined even though is correctly passed
+// NOTE: we could have an workaround by adding `number` to this list, but that would have not resolved the real bug.
+const UUID_PRIORITY_KEYS = ['eid', 'uuid', 'id', 'sys_date_created', 'number'];
 
 const inferUniqueID = (objectKeys) => {
   for (const key of UUID_PRIORITY_KEYS) {
@@ -67,8 +69,12 @@ const TableBase = ({
     // If no dataDisplay is being set, we should try to infer the type from values on the first object in `data` and then create a dataDisplay config with module types
     inferDataDisplay(data);
 
-  const uniqueID =
-    uniqueIdAttribute || data ? inferUniqueID(Object.keys(data[0])) : undefined;
+  // [fix] FDS-284: uniqueIdAttribute is always derived as undefined even though is correctly passed
+  const uniqueID = uniqueIdAttribute
+    ? uniqueIdAttribute
+    : data
+    ? inferUniqueID(Object.keys(data[0]))
+    : undefined;
 
   // // FDS-142: new action props
   let actionButtonMenuIndex = actions?.actionButtonMenuIndex;


### PR DESCRIPTION
Resolves [FDS-284](https://espressive.atlassian.net/browse/FDS-284).
References: [DEV-15895](https://espressive.atlassian.net/browse/DEV-15895).

The [auto-uniqueIdAttribute-inference logic](https://github.com/Espressive/cascara/compare/develop...fix/FDS-284?expand=1#diff-a1b1889e48abb6e2ea0bdd7401e5f17dbefc252290534b4ce626bbc6e6f09abaR14) in TableBase returns `undefined` given the following sircumstances:

- a faulty check that always returns `true`, forcing the [auto-uniqueIdAttribute-inference logic](https://github.com/Espressive/cascara/compare/develop...fix/FDS-284?expand=1#diff-a1b1889e48abb6e2ea0bdd7401e5f17dbefc252290534b4ce626bbc6e6f09abaR14) to always kick-in.
- the `data` prop having a `uniqueIdAttribute` that is not  listed in [UUID_PRIORITY_KEYS](https://github.com/Espressive/cascara/compare/develop...fix/FDS-284?expand=1#diff-a1b1889e48abb6e2ea0bdd7401e5f17dbefc252290534b4ce626bbc6e6f09abaR12)

This adds `number` to UUID_PRIORITY_KEYS and improves the check so it returns `uniqueIdAttribute` right away if specified.