### PR TITLE
chore(FDS-249): all modules need to present the aria-label on the inputs

### DIFF
--- a/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
+++ b/packages/cascara/src/modules/DataCheckbox/DataCheckbox.js
@@ -36,6 +36,7 @@ const DataCheckbox = ({
       <Checkbox
         {...rest}
         {...checkbox}
+        aria-label={label}
         className={styles.Input}
         id={label}
         name={attribute || label}

--- a/packages/cascara/src/modules/DataJson/DataJson.js
+++ b/packages/cascara/src/modules/DataJson/DataJson.js
@@ -36,6 +36,7 @@ const DataJson = ({
       {label && isLabeled && <span className={styles.Label}>{label}</span>}
       <Input
         {...rest}
+        aria-label={label}
         as={TextareaAutosize}
         className={styles.Input}
         defaultValue={jsonValue}

--- a/packages/cascara/src/modules/DataNumber/DataNumber.js
+++ b/packages/cascara/src/modules/DataNumber/DataNumber.js
@@ -34,6 +34,7 @@ const DataNumber = ({
       {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <Input
         {...rest}
+        aria-label={label}
         className={styles.Input}
         defaultValue={value}
         id={label}

--- a/packages/cascara/src/modules/DataRadio/DataRadio.js
+++ b/packages/cascara/src/modules/DataRadio/DataRadio.js
@@ -58,7 +58,7 @@ const DataRadio = ({
     <RadioGroup
       {...radio}
       {...rest}
-      aria-label='fruits'
+      aria-label={label}
       className={styles.Radio}
     >
       {options

--- a/packages/cascara/src/modules/DataSelect/DataSelect.js
+++ b/packages/cascara/src/modules/DataSelect/DataSelect.js
@@ -43,6 +43,7 @@ const DataSelect = ({
       {label && isLabeled && <span className={styles.Label}>{label}</span>}
       <Input
         {...rest}
+        aria-label={label}
         as='select'
         className={styles.Input}
         defaultValue={value}

--- a/packages/cascara/src/modules/DataTextArea/DataTextArea.js
+++ b/packages/cascara/src/modules/DataTextArea/DataTextArea.js
@@ -35,6 +35,7 @@ const DataTextArea = ({
       {label && isLabeled && <span className={styles.LabelText}>{label}</span>}
       <Input
         {...rest}
+        aria-label={label}
         as={TextareaAutosize}
         className={styles.Input}
         defaultValue={value}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,7 +1636,7 @@
     strip-json-comments "^3.1.1"
 
 "@espressive/cascara@file:packages/cascara":
-  version "0.4.2-alpha.28"
+  version "0.4.2-alpha.31"
   dependencies:
     "@babel/runtime" "7.14.0"
     "@espressive/icons" "^0.0.2-alpha.5"


### PR DESCRIPTION
Resolves FDS-249.

This is the first step towards having accessible inputs, `aria-label` is added to all inputs.

We still need to discuss our strategy on `display` mode:

- [ ] should we add `aria-label` to spans in `display` mode?
- [ ] is it ok to use both `aria-label` and the `<label>` tag together?
- [ ] if either `aria-label` or `<label>` but not both, which one over the other?