### PR TITLE
chore(FDS-311): Add empty and loading status to JSONPlaceholder

### DIFF
--- a/packages/cascara/src/placeholders/JsonPlaceholder/JsonPlaceholder.fixture.js
+++ b/packages/cascara/src/placeholders/JsonPlaceholder/JsonPlaceholder.fixture.js
@@ -17,6 +17,9 @@ export default {
     />
   ),
   default: <JsonPlaceholder data={testJson} />,
+  loading: <JsonPlaceholder data={null} />,
+  emptyArray: <JsonPlaceholder data={[]} />,
+  emptyObject: <JsonPlaceholder data={{}} />,
   isInitialOpen: <JsonPlaceholder data={testJson} isInitialOpen />,
   style: (
     <JsonPlaceholder

--- a/packages/cascara/src/placeholders/JsonPlaceholder/JsonPlaceholder.js
+++ b/packages/cascara/src/placeholders/JsonPlaceholder/JsonPlaceholder.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import pt from 'prop-types';
 import styles from './JsonPlaceholder.module.scss';
+import getStatusFromDataLength from '../../lib/getStatusFromDataLength';
+import Empty from '../../private/TemporaryEmpty';
+import Loading from '../../private/TemporaryLoading';
 
 const propTypes = {
   /** Accepts a JSON object or array to render */
@@ -16,20 +19,36 @@ const JsonPlaceholder = ({
   isInitialOpen = false,
   title = 'JSON',
   ...rest
-}) => (
-  <details
-    {...rest}
-    className={
-      rest?.className ? `${styles.Details} ${rest.className}` : styles.Details
-    }
-    open={isInitialOpen}
-  >
-    <summary className={styles.Summary}>{title}</summary>
-    <pre className={styles.Pre}>
-      <code>{JSON.stringify(data, null, '  ')}</code>
-    </pre>
-  </details>
-);
+}) => {
+  const records = Array.isArray(data)
+    ? data.length
+    : typeof data === 'object' && data !== null
+    ? Object.keys(data).length
+    : null;
+
+  const { isEmpty, isLoading } = getStatusFromDataLength(records);
+
+  return !isEmpty ? (
+    <details
+      {...rest}
+      className={
+        rest?.className ? `${styles.Details} ${rest.className}` : styles.Details
+      }
+      open={isInitialOpen}
+    >
+      <summary className={styles.Summary}>{title}</summary>
+      {!isLoading ? (
+        <pre className={styles.Pre}>
+          <code>{JSON.stringify(data, null, '  ')}</code>
+        </pre>
+      ) : (
+        <Loading />
+      )}
+    </details>
+  ) : (
+    <Empty />
+  );
+};
 
 JsonPlaceholder.propTypes = propTypes;
 


### PR DESCRIPTION
## New Component Checklist

- [-] Includes unit tests for _ALL_ required FDS use cases
- [-] Does not mute any top level API props in React
- [-] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [-] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node
Snapshots
Default:
![image](https://user-images.githubusercontent.com/87443054/130120989-55794a2e-ca5a-471e-a872-cae61058f93e.png)
Loading:
![image](https://user-images.githubusercontent.com/87443054/130121041-8711d62d-a322-47d6-b115-a8b6f5c3bd9d.png)
EmptyArray and EmptyObject:
![image](https://user-images.githubusercontent.com/87443054/130121147-b7b97e83-0419-49f4-a97f-e7e1451dd6d1.png)
Style:
![image](https://user-images.githubusercontent.com/87443054/130121231-655af0e6-4536-47c0-8ed2-998dd26b8b0c.png)
Title:
![image](https://user-images.githubusercontent.com/87443054/130121264-87bbe9b0-ed7f-4ab2-b09f-cdff754d8cd8.png)


