### PR TITLE
hotfix(FDS-352): Update logic for empty/loading in Form

### DIFF
--- a/.changeset/neat-days-serve.md
+++ b/.changeset/neat-days-serve.md
@@ -1,0 +1,5 @@
+---
+'@espressive/cascara': patch
+---
+
+hotfix(FDS-352): Add optional chaining for getting length on dataDisplay object keys in Form

--- a/.changeset/quick-glasses-look.md
+++ b/.changeset/quick-glasses-look.md
@@ -1,0 +1,5 @@
+---
+'@espressive/cascara': patch
+---
+
+hotfix(FDS-352): Update logic for empty/loading in Form

--- a/packages/cascara/src/lib/getStatusFromDataLength.js
+++ b/packages/cascara/src/lib/getStatusFromDataLength.js
@@ -1,6 +1,6 @@
 const getStatusFromDataLength = (length) => {
-  const isLoading = !length && length !== 0;
-  const isEmpty = !isLoading && length === 0;
+  const isLoading = Boolean(!length && length !== 0);
+  const isEmpty = Boolean(!isLoading && length === 0);
 
   return {
     isEmpty,

--- a/packages/cascara/src/ui/Form/Form.fixture.js
+++ b/packages/cascara/src/ui/Form/Form.fixture.js
@@ -144,7 +144,7 @@ const EmptyForm = (props) => (
     <p>
       If a form does not receive dataDisplay prop as an array with values, the
       Form component will notify there is not data to present.
-    </p>{' '}
+    </p>
     <Form {...props} />
   </>
 );
@@ -162,7 +162,7 @@ export default {
   dataWithDisplay: (
     <DataWithDisplay actions={actions} data={data} dataDisplay={dataDisplay} />
   ),
-  empty: <EmptyForm actions={actions} data={{}} dataDisplay={[]} />,
+  empty: <EmptyForm actions={actions} data={{}} />,
   initialEditing: (
     <InitialEditing
       actions={actions}
@@ -171,7 +171,5 @@ export default {
       isInitialEditing
     />
   ),
-  loading: (
-    <LoadingForm actions={actions} data={undefined} dataDisplay={dataDisplay} />
-  ),
+  loading: <LoadingForm />,
 };

--- a/packages/cascara/src/ui/Form/Form.js
+++ b/packages/cascara/src/ui/Form/Form.js
@@ -189,9 +189,10 @@ const Form = ({
     WARNING_STRINGS.INVALID_EDITING_AND_DISPLAY
   );
 
-  const { isEmpty } = getStatusFromDataLength(Object.keys(dataDisplay)?.length);
-
-  const isLoading = !data;
+  const { isEmpty, isLoading } = getStatusFromDataLength(
+    // We convert data to an array to check its length
+    data && Object.keys(data).length
+  );
 
   const fields = formFields(dataDisplay, data);
 

--- a/packages/cascara/src/ui/Form/Form.js
+++ b/packages/cascara/src/ui/Form/Form.js
@@ -189,7 +189,7 @@ const Form = ({
     WARNING_STRINGS.INVALID_EDITING_AND_DISPLAY
   );
 
-  const { isEmpty } = getStatusFromDataLength(Object.keys(dataDisplay).length);
+  const { isEmpty } = getStatusFromDataLength(Object.keys(dataDisplay)?.length);
 
   const isLoading = !data;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2637,7 +2637,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@espressive/cascara@workspace:0.5.1, @espressive/cascara@workspace:packages/cascara":
+"@espressive/cascara@workspace:0.5.2, @espressive/cascara@workspace:packages/cascara":
   version: 0.0.0-use.local
   resolution: "@espressive/cascara@workspace:packages/cascara"
   dependencies:
@@ -9429,7 +9429,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docs@workspace:docs"
   dependencies:
-    "@espressive/cascara": "workspace:0.5.1"
+    "@espressive/cascara": "workspace:0.5.2"
     "@espressive/design-tokens": "workspace:0.1.5"
     "@espressive/legacy-css": "workspace:2.0.5"
     "@fluentui/react-northstar": 0.57.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2637,12 +2637,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@espressive/cascara@workspace:0.5.0, @espressive/cascara@workspace:packages/cascara":
+"@espressive/cascara@workspace:0.5.1, @espressive/cascara@workspace:packages/cascara":
   version: 0.0.0-use.local
   resolution: "@espressive/cascara@workspace:packages/cascara"
   dependencies:
     "@babel/runtime": 7.14.0
-    "@espressive/icons": "workspace:0.1.0"
+    "@espressive/icons": "workspace:0.2.0"
     "@espressive/legacy-css": "workspace:2.0.5"
     "@iconify-icons/ic": 1.1.5
     "@iconify/react": 1.1.4
@@ -2717,7 +2717,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@espressive/icons@workspace:0.1.0, @espressive/icons@workspace:packages/icons":
+"@espressive/icons@workspace:0.2.0, @espressive/icons@workspace:packages/icons":
   version: 0.0.0-use.local
   resolution: "@espressive/icons@workspace:packages/icons"
   dependencies:
@@ -9429,7 +9429,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docs@workspace:docs"
   dependencies:
-    "@espressive/cascara": "workspace:0.5.0"
+    "@espressive/cascara": "workspace:0.5.1"
     "@espressive/design-tokens": "workspace:0.1.5"
     "@espressive/legacy-css": "workspace:2.0.5"
     "@fluentui/react-northstar": 0.57.0


### PR DESCRIPTION
Form was looking at the dataDisplay value for determining if it was empty or not, instead of the data prop
