### PR TITLE
Chore(FDS-355) ViewConfigWarning: React does not recognize the isEditable prop on a DOM element.

### DIFF
--- a/packages/cascara/src/private/ViewConfig/ViewConfigBase.js
+++ b/packages/cascara/src/private/ViewConfig/ViewConfigBase.js
@@ -56,6 +56,8 @@ const ViewConfig = ({
   const renderOptions = (options, isSelected) =>
     options.map((option) => {
       const { currentSelection, ...setterFunctions } = state;
+      // isEditable should not propapate to MemoViewConfigItem component
+      delete option.isEditable;
       return (
         <MemoViewConfigItem
           {...option}


### PR DESCRIPTION
To get this warning in cosmos, I copied the values we get from CC and pass it as param in Cosmos.

## New Component Checklist

- [-] Includes unit tests for _ALL_ required FDS use cases
- [-] Does not mute any top level API props in React
- [-] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [-] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node
