### PR TITLE
chore(FDS-141) Make dangerfile not check for description comments for changes on develop/master

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -2,16 +2,7 @@ name: 'Danger JS'
 on:
   pull_request:
     types:
-      [
-        assigned,
-        edited,
-        labeled,
-        opened,
-        reopened,
-        synchronize,
-        unassigned,
-        unlabeled,
-      ]
+      [assigned, labeled, opened, reopened, synchronize, unassigned, unlabeled]
 
 jobs:
   danger:

--- a/packages/cascara/src/private/ViewConfig/ViewConfig.fixture.js
+++ b/packages/cascara/src/private/ViewConfig/ViewConfig.fixture.js
@@ -40,6 +40,7 @@ const All = (fixtureProps) => {
         original object in the selection. Only <code>label</code> is used in the
         menu display of the component.
       </p>
+
       <ViewConfig state={viewConfigState} {...fixtureProps} />
       <JsonPlaceholder
         data={viewConfigState?.currentSelection || {}}


### PR DESCRIPTION
Make danger file not check for description comments for changes on develop/master

## New Component Checklist

- [x] Includes unit tests for _ALL_ required FDS use cases
- [x] Does not mute any top level API props in React
- [x] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [x] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node
