### PR TITLE
Make AdminStructure compatible with legacy

### DIFF
--- a/.changeset/empty-melons-serve.md
+++ b/.changeset/empty-melons-serve.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+Make AdminStructure compatible with legacy

--- a/packages/cascara/src/structures/AdminStructure/AdminStructure.module.scss
+++ b/packages/cascara/src/structures/AdminStructure/AdminStructure.module.scss
@@ -30,12 +30,19 @@ $border: 1px solid rgba(0, 0, 0, 0.15);
 
   body,
   #root,
-  #next {
+  #next,
+  #app {
+    // #app is needed in our legacy application and can be removed someday
     height: 100%;
   }
 
+  #app .app-root {
+    display: contents;
+  }
+
   #root,
-  #next {
+  #next,
+  #app {
     display: grid;
     grid-template-columns: var(--nav-max-width) minmax(0, 1fr) var(
         --drawer-max-width

--- a/yarn.lock
+++ b/yarn.lock
@@ -2637,7 +2637,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@espressive/cascara@workspace:0.5.4, @espressive/cascara@workspace:packages/cascara":
+"@espressive/cascara@workspace:0.6.0, @espressive/cascara@workspace:packages/cascara":
   version: 0.0.0-use.local
   resolution: "@espressive/cascara@workspace:packages/cascara"
   dependencies:
@@ -9507,7 +9507,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docs@workspace:docs"
   dependencies:
-    "@espressive/cascara": "workspace:0.5.4"
+    "@espressive/cascara": "workspace:0.6.0"
     "@espressive/design-tokens": "workspace:0.1.5"
     "@espressive/legacy-css": "workspace:2.0.5"
     "@fluentui/react-northstar": 0.57.0


### PR DESCRIPTION
Adds CSS support for the AdminStructure to work within the legacy Admin app 
