### PR TITLE
fix(FDS-379) Fix cross browser issues with Structure Nav/Header

### DIFF
--- a/.changeset/nervous-poets-attack.md
+++ b/.changeset/nervous-poets-attack.md
@@ -1,0 +1,5 @@
+---
+'@espressive/cascara': patch
+---
+
+fix(FDS-379) Fix cross browser issues with Structure Nav/Header

--- a/packages/cascara/src/structures/AdminStructure/AdminStructure.module.scss
+++ b/packages/cascara/src/structures/AdminStructure/AdminStructure.module.scss
@@ -47,7 +47,7 @@ $border: 1px solid rgba(0, 0, 0, 0.15);
     grid-template-columns: var(--nav-max-width) minmax(0, 1fr) var(
         --drawer-max-width
       );
-    grid-template-rows: minmax(0, 4rem) auto;
+    grid-template-rows: 4rem auto;
     grid-template-areas:
       'header header header'
       'nav main drawer';

--- a/packages/cascara/src/structures/AdminStructure/components/Nav/Nav.module.scss
+++ b/packages/cascara/src/structures/AdminStructure/components/Nav/Nav.module.scss
@@ -141,6 +141,7 @@ $active-background-color: var(--brand-color, #ddd);
       box-shadow 200ms ease-in-out;
     white-space: nowrap;
     text-overflow: ellipsis;
+    -webkit-appearance: none; // Safari if type=button
 
     // @include media-gt-sm {
     //   text-overflow: ellipsis;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2646,7 +2646,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@espressive/cascara@workspace:0.8.0, @espressive/cascara@workspace:packages/cascara":
+"@espressive/cascara@workspace:0.8.1, @espressive/cascara@workspace:packages/cascara":
   version: 0.0.0-use.local
   resolution: "@espressive/cascara@workspace:packages/cascara"
   dependencies:
@@ -9519,7 +9519,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docs@workspace:docs"
   dependencies:
-    "@espressive/cascara": "workspace:0.8.0"
+    "@espressive/cascara": "workspace:0.8.1"
     "@espressive/design-tokens": "workspace:0.1.5"
     "@espressive/legacy-css": "workspace:2.0.5"
     "@fluentui/react-northstar": 0.57.0


### PR DESCRIPTION
This is a patch fix to address two small CSS issues with the AdminStructure in both Safari and Firefox. Related tickets are linked to the FDS ticket.