### PR TITLE
fix(FDS-372): [ViewConfig] - allow spaces in attr search box

### DIFF
--- a/packages/cascara/src/private/ViewConfig/ViewConfigBase.js
+++ b/packages/cascara/src/private/ViewConfig/ViewConfigBase.js
@@ -68,7 +68,7 @@ const ViewConfig = ({
     });
 
   const handleSearchValue = useCallback((e) => {
-    setSearchValue(e.target.value.trim());
+    setSearchValue(e.target.value);
   }, []);
 
   const handleClearSearch = useCallback(() => {


### PR DESCRIPTION
## Resolves [FDS-372.](https://espressive.atlassian.net/browse/FDS-372)

**ViewConfig** trim() is preventing the ability to type spaces in the attribute search box.

> **Question:** A comment in DEV-17258 reads _"...putting the trim() on the search state and not the input state."_, is the search state part of Cascara?