### PR TITLE
fix(FDS-380) Firefox scroll working with fallback

### DIFF
--- a/.changeset/shaggy-suits-begin.md
+++ b/.changeset/shaggy-suits-begin.md
@@ -1,0 +1,5 @@
+---
+'@espressive/cascara': patch
+---
+
+fix(FDS-380) Firefox scroll working with fallback

--- a/.cosmos/config.json
+++ b/.cosmos/config.json
@@ -3,6 +3,7 @@
   "rootDir": "../",
   "staticPath": ".cosmos/public",
   "exportPath": "build/cosmos",
+  "port": 4000,
   "watchDirs": ["packages/cascara/src/**/**"],
   "webpack": {
     "configPath": "react-scripts/config/webpack.config",

--- a/packages/cascara/styles/_scroll.scss
+++ b/packages/cascara/styles/_scroll.scss
@@ -24,18 +24,21 @@
 }
 
 @mixin vertical {
+  overflow-y: auto;
   overflow-y: overlay;
 
   @extend %scrollbars;
 }
 
 @mixin horizontal {
+  overflow-x: auto;
   overflow-x: overlay;
 
   @extend %scrollbars;
 }
 
 @mixin all {
+  overflow: auto;
   overflow: overlay;
 
   @extend %scrollbars;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2646,7 +2646,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@espressive/cascara@workspace:0.8.1, @espressive/cascara@workspace:packages/cascara":
+"@espressive/cascara@workspace:0.8.2, @espressive/cascara@workspace:packages/cascara":
   version: 0.0.0-use.local
   resolution: "@espressive/cascara@workspace:packages/cascara"
   dependencies:
@@ -9519,7 +9519,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docs@workspace:docs"
   dependencies:
-    "@espressive/cascara": "workspace:0.8.1"
+    "@espressive/cascara": "workspace:0.8.2"
     "@espressive/design-tokens": "workspace:0.1.5"
     "@espressive/legacy-css": "workspace:2.0.5"
     "@fluentui/react-northstar": 0.57.0


### PR DESCRIPTION
This resolves an issue in our scroll mixin within Cascara where we did not have an overflow setting for scroll that Firefox could use, so we did not have any scrolling at all.

If using Cosmos, this fixture can be used locally to validate scrolling is now working in Cosmos. http://localhost:4000/_renderer.html?_fixtureId=%7B%22path%22%3A%22packages%2Fcascara%2Fsrc%2Fstructures%2FAdminStructure%2FAdminStructure.fixture.js%22%2C%22name%22%3A%22no-drawer%22%7D