### PR TITLE
feat(DEV-373):  [Cascara] - Columns component mvp

### DIFF
--- a/.changeset/fifty-moons-build.md
+++ b/.changeset/fifty-moons-build.md
@@ -3,4 +3,4 @@
 '@espressive/cascara': minor
 ---
 
-feat(FDS-374): [Cascara] - Section component MVP
+feat(FDS-374): [Cascara] - Section and Title component MVP

--- a/.changeset/short-rabbits-joke.md
+++ b/.changeset/short-rabbits-joke.md
@@ -1,0 +1,6 @@
+---
+"docs": patch
+"@espressive/cascara": patch
+---
+
+feat(DEV-373):  [Cascara] - Columns component mvp

--- a/.changeset/short-rabbits-joke.md
+++ b/.changeset/short-rabbits-joke.md
@@ -1,6 +1,6 @@
 ---
-"docs": patch
-"@espressive/cascara": patch
+'docs': patch
+'@espressive/cascara': patch
 ---
 
-feat(DEV-373):  [Cascara] - Columns component mvp
+feat(FDS-373): [Columns] - Component mvp

--- a/docs/src/lib/MDX_COMPONENTS.js
+++ b/docs/src/lib/MDX_COMPONENTS.js
@@ -9,6 +9,7 @@ import {
   Admin,
   Button,
   Chat,
+  Columns,
   Dashboard,
   Form,
   JsonPlaceholder,
@@ -17,6 +18,7 @@ import {
   Section,
   Table,
   Tabs,
+  Title,
   usePaginationState,
 } from '@espressive/cascara';
 
@@ -54,6 +56,7 @@ const cascaraComponents = {
       <Chat {...props} />
     </ChatProvider>
   ),
+  Columns: (props) => <Columns {...props} />,
   Dashboard: (props) => <Dashboard {...props} />,
   Form: (props) => <Form {...props} />,
   JsonPlaceholder: (props) => <JsonPlaceholder {...props} />,
@@ -62,6 +65,7 @@ const cascaraComponents = {
   Section: (props) => <Section {...props} />,
   Table: (props) => <Table {...props} />,
   Tabs: (props) => <Tabs {...props} />,
+  Title: (props) => <Title {...props} />,
 };
 
 const privateComponents = {

--- a/packages/cascara/src/ui/Columns/Columns.fixture.js
+++ b/packages/cascara/src/ui/Columns/Columns.fixture.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import Columns from '.';
+
+export default {
+  withDefaultProps: (
+    <>
+      <p>
+        This example shows the columns component without a `count` prop. That
+        is, with default props.
+      </p>
+      <Columns>
+        <div>Column 1</div>
+        <div>Column 2</div>
+      </Columns>
+    </>
+  ),
+  withThreeColumns: (
+    <>
+      <p>
+        This example shows the columns component with the <b>count</b> prop set
+        to 3.
+        <br />
+        Please note that the number of children must be equal to the{' '}
+        <b>count</b> prop, otherwise it will break the layout.
+      </p>
+      <Columns count={3}>
+        <div>Column 1</div>
+        <div>Column 2</div>
+        <div>Column 3</div>
+      </Columns>
+    </>
+  ),
+};

--- a/packages/cascara/src/ui/Columns/Columns.js
+++ b/packages/cascara/src/ui/Columns/Columns.js
@@ -9,26 +9,45 @@ import styles from './Columns.module.scss';
 const cx = classNames.bind(styles);
 
 const propTypes = {
+  /** HTML tag to allow polymorphism */
+  as: pt.string,
   /** The section content */
   children: pt.oneOfType([pt.arrayOf(pt.node), pt.node]),
   /** Columns can have css class name */
   className: pt.string,
   /** The number of columns to allocate */
   count: pt.number,
+  /** Columns can have inline styles */
+  style: pt.shape(pt.object),
 };
 
-const Columns = ({ count = 2, children, className, ...rest }) => (
-  <Boundaries>
-    <Role
-      className={cx('Columns', className)}
-      style={{ columnCount: count }}
-      {...rest}
-    >
-      {children}
-    </Role>
-  </Boundaries>
-);
+const Columns = ({
+  as = 'div',
+  count = 2,
+  children,
+  className,
+  style,
+  ...rest
+}) => {
+  let mergedStyle = {
+    columnCount: count,
+  };
 
+  if (style) {
+    mergedStyle = {
+      ...style,
+      ...mergedStyle,
+    };
+  }
+
+  return (
+    <Boundaries>
+      <Role className={cx('Columns', className)} style={mergedStyle} {...rest}>
+        {children}
+      </Role>
+    </Boundaries>
+  );
+};
 Columns.propTypes = propTypes;
 
 export { propTypes };

--- a/packages/cascara/src/ui/Columns/Columns.js
+++ b/packages/cascara/src/ui/Columns/Columns.js
@@ -16,14 +16,14 @@ const propTypes = {
   /** Columns can have css class name */
   className: pt.string,
   /** The number of columns to allocate */
-  count: pt.number,
+  count: pt.oneOfType([pt.number, pt.oneOf(['auto'])]),
   /** Columns can have inline styles */
   style: pt.shape(pt.object),
 };
 
 const Columns = ({
   as = 'div',
-  count = 2,
+  count = 'auto',
   children,
   className,
   style,
@@ -33,7 +33,7 @@ const Columns = ({
     columnCount: count,
   };
 
-  if (style) {
+  if (typeof count === 'number' && style) {
     mergedStyle = {
       ...style,
       ...mergedStyle,

--- a/packages/cascara/src/ui/Columns/Columns.js
+++ b/packages/cascara/src/ui/Columns/Columns.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import pt from 'prop-types';
+import { Role } from 'reakit';
+import classNames from 'classnames/bind';
+
+import Boundaries from '../../system-components/Boundaries';
+import styles from './Columns.module.scss';
+
+const cx = classNames.bind(styles);
+
+const propTypes = {
+  /** The section content */
+  children: pt.oneOfType([pt.arrayOf(pt.node), pt.node]),
+  /** Columns can have css class name */
+  className: pt.string,
+  /** The number of columns to allocate */
+  count: pt.number,
+};
+
+const Columns = ({ count = 2, children, className, ...rest }) => (
+  <Boundaries>
+    <Role
+      className={cx('Columns', className)}
+      style={{ columnCount: count }}
+      {...rest}
+    >
+      {children}
+    </Role>
+  </Boundaries>
+);
+
+Columns.propTypes = propTypes;
+
+export { propTypes };
+export default Columns;

--- a/packages/cascara/src/ui/Columns/Columns.mdx
+++ b/packages/cascara/src/ui/Columns/Columns.mdx
@@ -5,7 +5,7 @@ propTable: Columns.js
 
 ```jsx
 ---
-title: An example use of Columns with default props (2 columns)
+title: An example use of Columns with automatic columns based on width, which will change depending on the width of the Columns container.
 ---
 <Columns>
   <div key='Column 1'>Column 1</div>

--- a/packages/cascara/src/ui/Columns/Columns.mdx
+++ b/packages/cascara/src/ui/Columns/Columns.mdx
@@ -1,0 +1,16 @@
+---
+title: Columns
+propTable: Columns.js
+---
+
+```jsx
+---
+title: An example use of Columns with default props (2 columns)
+---
+<Columns>
+  <div key='Column 1'>Column 1</div>
+  <div key='Column 2'>Column 2</div>
+</Columns>
+```
+
+> The children count must match the `count` prop, otherwise the layout will be broken.

--- a/packages/cascara/src/ui/Columns/Columns.module.scss
+++ b/packages/cascara/src/ui/Columns/Columns.module.scss
@@ -1,6 +1,4 @@
 $masonry-gutter: 2rem;
-$widget-border-radius: 0.5em;
-$widget-background: #f0f0f0;
 
 .Columns {
   display: block;

--- a/packages/cascara/src/ui/Columns/Columns.module.scss
+++ b/packages/cascara/src/ui/Columns/Columns.module.scss
@@ -1,4 +1,12 @@
+$masonry-gutter: 2em;
+$widget-border-radius: 0.5em;
+$widget-background: #f0f0f0;
+
 .Columns {
+  display: block;
+  columns: 30rem;
+  gap: $masonry-gutter;
+
   & > * {
     -webkit-column-break-inside: avoid;
     page-break-inside: avoid;

--- a/packages/cascara/src/ui/Columns/Columns.module.scss
+++ b/packages/cascara/src/ui/Columns/Columns.module.scss
@@ -1,4 +1,4 @@
-$masonry-gutter: 2em;
+$masonry-gutter: 2rem;
 $widget-border-radius: 0.5em;
 $widget-background: #f0f0f0;
 

--- a/packages/cascara/src/ui/Columns/Columns.module.scss
+++ b/packages/cascara/src/ui/Columns/Columns.module.scss
@@ -1,0 +1,7 @@
+.Columns {
+  & > * {
+    -webkit-column-break-inside: avoid;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+}

--- a/packages/cascara/src/ui/Columns/Columns.test.js
+++ b/packages/cascara/src/ui/Columns/Columns.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import fixtures from './Columns.fixture';
+import Columns from './Columns';
+
+describe('<Columns />', () => {
+  // run snapshot test for all fixtures.
+  test('snapshot tests', async () => {
+    for (const fixture in fixtures) {
+      const view = render(fixtures[fixture]).container;
+
+      expect(view).toMatchSnapshot();
+    }
+  });
+
+  // this test expands the number of columns to 10.
+  test('snapshot tests n', async () => {
+    for (let columnsCount = 3; columnsCount < 11; columnsCount++) {
+      const content = Array(columnsCount)
+        .fill(1, 0)
+        .map((_, idx) => (
+          <div key={`Column ${idx + 1}`}>{`Column ${idx + 1}`}</div>
+        ));
+
+      const view = render(
+        <Columns count={columnsCount}>{content}</Columns>
+      ).container;
+
+      expect(view).toMatchSnapshot();
+    }
+  });
+});

--- a/packages/cascara/src/ui/Columns/Columns.test.snap
+++ b/packages/cascara/src/ui/Columns/Columns.test.snap
@@ -1,0 +1,289 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Columns /> snapshot tests 1`] = `
+<div>
+  <p>
+    This example shows the columns component without a \`count\` prop. That is, with default props.
+  </p>
+  <div
+    class="Columns"
+    style="column-count: 2;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Columns /> snapshot tests 2`] = `
+<div>
+  <p>
+    This example shows the columns component with the 
+    <b>
+      count
+    </b>
+     prop set to 3.
+    <br />
+    Please note that the number of children must be equal to the
+     
+    <b>
+      count
+    </b>
+     prop, otherwise it will break the layout.
+  </p>
+  <div
+    class="Columns"
+    style="column-count: 3;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+    <div>
+      Column 3
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Columns /> snapshot tests n 1`] = `
+<div>
+  <div
+    class="Columns"
+    style="column-count: 3;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+    <div>
+      Column 3
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Columns /> snapshot tests n 2`] = `
+<div>
+  <div
+    class="Columns"
+    style="column-count: 4;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+    <div>
+      Column 3
+    </div>
+    <div>
+      Column 4
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Columns /> snapshot tests n 3`] = `
+<div>
+  <div
+    class="Columns"
+    style="column-count: 5;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+    <div>
+      Column 3
+    </div>
+    <div>
+      Column 4
+    </div>
+    <div>
+      Column 5
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Columns /> snapshot tests n 4`] = `
+<div>
+  <div
+    class="Columns"
+    style="column-count: 6;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+    <div>
+      Column 3
+    </div>
+    <div>
+      Column 4
+    </div>
+    <div>
+      Column 5
+    </div>
+    <div>
+      Column 6
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Columns /> snapshot tests n 5`] = `
+<div>
+  <div
+    class="Columns"
+    style="column-count: 7;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+    <div>
+      Column 3
+    </div>
+    <div>
+      Column 4
+    </div>
+    <div>
+      Column 5
+    </div>
+    <div>
+      Column 6
+    </div>
+    <div>
+      Column 7
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Columns /> snapshot tests n 6`] = `
+<div>
+  <div
+    class="Columns"
+    style="column-count: 8;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+    <div>
+      Column 3
+    </div>
+    <div>
+      Column 4
+    </div>
+    <div>
+      Column 5
+    </div>
+    <div>
+      Column 6
+    </div>
+    <div>
+      Column 7
+    </div>
+    <div>
+      Column 8
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Columns /> snapshot tests n 7`] = `
+<div>
+  <div
+    class="Columns"
+    style="column-count: 9;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+    <div>
+      Column 3
+    </div>
+    <div>
+      Column 4
+    </div>
+    <div>
+      Column 5
+    </div>
+    <div>
+      Column 6
+    </div>
+    <div>
+      Column 7
+    </div>
+    <div>
+      Column 8
+    </div>
+    <div>
+      Column 9
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Columns /> snapshot tests n 8`] = `
+<div>
+  <div
+    class="Columns"
+    style="column-count: 10;"
+  >
+    <div>
+      Column 1
+    </div>
+    <div>
+      Column 2
+    </div>
+    <div>
+      Column 3
+    </div>
+    <div>
+      Column 4
+    </div>
+    <div>
+      Column 5
+    </div>
+    <div>
+      Column 6
+    </div>
+    <div>
+      Column 7
+    </div>
+    <div>
+      Column 8
+    </div>
+    <div>
+      Column 9
+    </div>
+    <div>
+      Column 10
+    </div>
+  </div>
+</div>
+`;

--- a/packages/cascara/src/ui/Columns/Columns.test.snap
+++ b/packages/cascara/src/ui/Columns/Columns.test.snap
@@ -7,7 +7,7 @@ exports[`<Columns /> snapshot tests 1`] = `
   </p>
   <div
     class="Columns"
-    style="column-count: 2;"
+    style="column-count: auto;"
   >
     <div>
       Column 1

--- a/packages/cascara/src/ui/Columns/__globals.js
+++ b/packages/cascara/src/ui/Columns/__globals.js
@@ -1,0 +1,10 @@
+import pt from 'prop-types';
+
+export const PROP_TYPES = {
+  /** The section content */
+  children: pt.oneOfType([pt.arrayOf(pt.node), pt.node]),
+  /** Columns can have css class name */
+  className: pt.string,
+  /** The number of columns to allocate */
+  count: pt.number,
+};

--- a/packages/cascara/src/ui/Columns/index.js
+++ b/packages/cascara/src/ui/Columns/index.js
@@ -1,0 +1,1 @@
+export { default } from './Columns';

--- a/packages/cascara/src/ui/index.js
+++ b/packages/cascara/src/ui/index.js
@@ -4,6 +4,7 @@
 
 export { default as ActionStack } from './ActionStack';
 export { default as Chat } from './Chat';
+export { default as Columns } from './Columns';
 export { default as Dashboard } from './Dashboard';
 export { default as Form, formPropTypes } from './Form';
 export { default as List } from './List';


### PR DESCRIPTION
## Resolves [FDS-373](https://espressive.atlassian.net/browse/FDS-373).

Add a new component called Columns that when wrapped around children will cause those children to display in columns using CSS.
> this is NOT grid. 

### Snapshots
Snapshots created for the new component.

### Fixtures
Fixtures created for the new component.

## New Component [Checklist](url)

- [x] Includes unit tests for _ALL_ required FDS use cases
- [x] Does not mute any top level API props in React
- [x] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [x] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node
