### PR TITLE
feat(FDS-371): [Cascara] - improve fallback component

### DIFF
--- a/.changeset/smooth-steaks-sin.md
+++ b/.changeset/smooth-steaks-sin.md
@@ -1,5 +1,5 @@
 ---
-"@espressive/cascara": patch
+'@espressive/cascara': patch
 ---
 
-feat(FDS-371): [Cascara] - improve fallback component
+feat(FDS-371): [Boundaries] - improve error fallback component

--- a/.changeset/smooth-steaks-sin.md
+++ b/.changeset/smooth-steaks-sin.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+feat(FDS-371): [Cascara] - improve fallback component

--- a/packages/cascara/src/system-components/Boundaries/Boundaries.fixture.js
+++ b/packages/cascara/src/system-components/Boundaries/Boundaries.fixture.js
@@ -25,6 +25,6 @@ export default {
     </Boundaries>
   ),
   invalidFallbacks: <InvalidFallbacks />,
-  ErrorFallback: <ErrorFallback />,
+  ErrorFallback: <ErrorFallback error={{ message: 'This is a dummy error' }} />,
   SuspenseFallback: <SuspenseFallback />,
 };

--- a/packages/cascara/src/system-components/Boundaries/fallbacks/ErrorFallback.js
+++ b/packages/cascara/src/system-components/Boundaries/fallbacks/ErrorFallback.js
@@ -1,6 +1,7 @@
-import React, { useCallback, useState } from 'react';
-import { Checkbox, Role } from 'reakit';
+import React, { useCallback } from 'react';
 import pt from 'prop-types';
+
+import Button from '../../../atoms/Button/Button';
 
 const propTypes = {
   // eslint-disable-next-line react/forbid-prop-types -- error objects
@@ -9,44 +10,25 @@ const propTypes = {
 };
 
 const ErrorFallback = ({ error, resetErrorBoundary }) => {
-  const checkedFromLS =
-    window.localStorage.getItem('ESPRESSIVE_SHOW_ERRORS') === 'true';
-  const [checked, setChecked] = useState(checkedFromLS);
-  const showError = process.env.NODE_ENV === 'development' || checked;
-
-  const hangleCheckboxClick = useCallback(() => {
-    setChecked(!checked);
-  }, [checked]);
-
-  const hangleTryAgainClick = useCallback(() => {
-    window.localStorage.setItem('ESPRESSIVE_SHOW_ERRORS', checked);
-
+  const showError = process.env.NODE_ENV === 'development';
+  const handleTryAgain = useCallback(() => {
     if (resetErrorBoundary) {
       resetErrorBoundary();
     }
-  }, [checked, resetErrorBoundary]);
+  }, [resetErrorBoundary]);
 
   return (
-    <Role className='ui tiny error message' role='alert'>
+    <div className='ui tiny error message' role='alert'>
       <div className='header'>Something went wrong:</div>
-      {showError && <pre>{error?.message}</pre>}
-      <br />
-      <button
-        className='ui negative button'
-        onClick={hangleTryAgainClick}
-        type='button'
-      >
+      {showError && (
+        <p>
+          <pre>{error?.message}</pre>
+        </p>
+      )}
+      <Button onClick={handleTryAgain} outcome='negative' type='button'>
         Try again
-      </button>
-      <label className='ui' htmlFor='chkAlwaysShowErrors'>
-        <Checkbox
-          checked={checked}
-          id='chkAlwaysShowErrors'
-          onChange={hangleCheckboxClick}
-        />{' '}
-        Always show errors
-      </label>
-    </Role>
+      </Button>
+    </div>
   );
 };
 

--- a/packages/cascara/src/system-components/Boundaries/fallbacks/ErrorFallback.js
+++ b/packages/cascara/src/system-components/Boundaries/fallbacks/ErrorFallback.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
+import { Checkbox, Role } from 'reakit';
 import pt from 'prop-types';
 
 const propTypes = {
@@ -8,18 +9,44 @@ const propTypes = {
 };
 
 const ErrorFallback = ({ error, resetErrorBoundary }) => {
+  const checkedFromLS =
+    window.localStorage.getItem('ESPRESSIVE_SHOW_ERRORS') === 'true';
+  const [checked, setChecked] = useState(checkedFromLS);
+  const showError = process.env.NODE_ENV === 'development' || checked;
+
+  const hangleCheckboxClick = useCallback(() => {
+    setChecked(!checked);
+  }, [checked]);
+
+  const hangleTryAgainClick = useCallback(() => {
+    window.localStorage.setItem('ESPRESSIVE_SHOW_ERRORS', checked);
+
+    if (resetErrorBoundary) {
+      resetErrorBoundary();
+    }
+  }, [checked, resetErrorBoundary]);
+
   return (
-    <div className='ui tiny error message' role='alert'>
+    <Role className='ui tiny error message' role='alert'>
       <div className='header'>Something went wrong:</div>
-      <pre>{error?.message}</pre>
+      {showError && <pre>{error?.message}</pre>}
+      <br />
       <button
         className='ui negative button'
-        onClick={resetErrorBoundary}
+        onClick={hangleTryAgainClick}
         type='button'
       >
         Try again
       </button>
-    </div>
+      <label className='ui' htmlFor='chkAlwaysShowErrors'>
+        <Checkbox
+          checked={checked}
+          id='chkAlwaysShowErrors'
+          onChange={hangleCheckboxClick}
+        />{' '}
+        Always show errors
+      </label>
+    </Role>
   );
 };
 


### PR DESCRIPTION
### Resolves [FDS-371](https://espressive.atlassian.net/browse/FDS-371).

Improve default Boundaries FallbackComponent to only show the error message in the UI during development environments with support for showing them with a localstorage key.

### Fixtures
Fixture for Boundaries updated with an error message.

## New Component Checklist

- [ ] Includes unit tests for _ALL_ required FDS use cases
- [ ] Does not mute any top level API props in React
- [ ] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [ ] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node
