### PR TITLE
feat(FDS-382): [Cascara] Stat component mvp

### DIFF
--- a/packages/cascara/src/ui/Stat/Stat.fixture.js
+++ b/packages/cascara/src/ui/Stat/Stat.fixture.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import Stat from '.';
+
+const clickHandler = () => console.log('click!');
+
+export default {
+  basic: <Stat label='Stat' value='50' />,
+  clickable: <Stat label='Stat' onClick={clickHandler} value='50' />,
+  fluid: <Stat fluid label='Stat' value='50' />,
+  withSub: <Stat label='Stat' sub='Component' value='50' />,
+};

--- a/packages/cascara/src/ui/Stat/Stat.js
+++ b/packages/cascara/src/ui/Stat/Stat.js
@@ -1,0 +1,62 @@
+import React, { useCallback } from 'react';
+import pt from 'prop-types';
+import classNames from 'classnames/bind';
+
+import { Clickable, Role } from 'reakit';
+import styles from './Stat.module.scss';
+
+const propTypes = {
+  /** Stats can have their own css class name */
+  className: pt.string,
+  /** Stats can be fuild */
+  fluid: pt.bool,
+  /** Stats can have a label */
+  label: pt.string,
+  /** Stats can be clickable */
+  onClick: pt.func,
+  /** Stats can have a sub text */
+  sub: pt.oneOfType([pt.number, pt.string]),
+  /** Stats can have a value */
+  value: pt.oneOfType([pt.number, pt.string]),
+};
+
+const cx = classNames.bind(styles);
+
+const WidgetStatsStat = ({ className, fluid, onClick, label, value, sub }) => {
+  // Instead of maintaining separate, competing styles for focus, we are setting focus on this clickable item on hover. This may be something we consider doing on other Clickable components with Reakit.
+  const handleFocus = useCallback(({ currentTarget, dispatchConfig }) => {
+    const { registrationName } = dispatchConfig;
+
+    if (registrationName === 'onMouseEnter') {
+      currentTarget.focus();
+    } else if (registrationName === 'onMouseLeave') {
+      currentTarget.blur();
+    }
+  }, []);
+
+  return (
+    <Role
+      as={onClick ? Clickable : 'div'}
+      className={cx('Stat', className, {
+        Clickable: Boolean(onClick),
+        Fluid: fluid,
+      })}
+      disabled={!onClick}
+      focusable={Boolean(onClick)}
+      key={label}
+      onClick={onClick}
+      onMouseEnter={handleFocus}
+      onMouseLeave={handleFocus}
+    >
+      <span className={styles.Value}>{value}</span>
+      <h4 className={styles.Label}>{label}</h4>
+      {sub && <span className={styles.Sub}>{sub}</span>}
+    </Role>
+  );
+};
+
+WidgetStatsStat.displayName = 'stat';
+WidgetStatsStat.propTypes = propTypes;
+
+export { propTypes };
+export default WidgetStatsStat;

--- a/packages/cascara/src/ui/Stat/Stat.mdx
+++ b/packages/cascara/src/ui/Stat/Stat.mdx
@@ -1,0 +1,8 @@
+---
+title: Stat
+propTable: Stat.js
+---
+
+```jsx
+<Stat label='Stat' sub='Component' />
+```

--- a/packages/cascara/src/ui/Stat/Stat.module.scss
+++ b/packages/cascara/src/ui/Stat/Stat.module.scss
@@ -1,0 +1,49 @@
+$masonry-gutter: 2em;
+$widget-border-radius: 0.5em;
+$widget-background: #f0f0f0;
+
+.Stat {
+  margin-bottom: $masonry-gutter;
+  break-inside: avoid;
+  display: inline-block;
+  position: relative;
+  padding: 1em;
+  background-color: $widget-background;
+  border-radius: $widget-border-radius;
+  display: flex;
+  flex-direction: column;
+
+  .Label {
+    margin: 0.25em 0;
+  }
+
+  .Value {
+    line-height: 1em;
+    font-size: 2em;
+  }
+
+  .Sub {
+    font-style: italic;
+    font-size: 0.875em;
+  }
+
+  .Clickable {
+    position: relative;
+
+    &:after {
+      content: '⬁';
+      font-size: 1.2em;
+      position: absolute;
+      right: 1em;
+      opacity: 0.25;
+    }
+
+    &:focus:after {
+      opacity: 0.5;
+    }
+  }
+
+  .Fluid {
+    display: block;
+  }
+}

--- a/packages/cascara/src/ui/Stat/Stat.test.js
+++ b/packages/cascara/src/ui/Stat/Stat.test.js
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+
+import fixtures from './Stat.fixture';
+
+describe('stat', () => {
+  //Run snapshot test for all fixtures
+  test('snapshot tests', async () => {
+    for (const fixture in fixtures) {
+      const view = render(fixtures[fixture]).container;
+
+      expect(view).toMatchSnapshot();
+    }
+  });
+});

--- a/packages/cascara/src/ui/Stat/Stat.test.snap
+++ b/packages/cascara/src/ui/Stat/Stat.test.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`stat snapshot tests 1`] = `
+<div>
+  <div
+    class="Stat"
+    disabled=""
+    focusable="false"
+  >
+    <span
+      class="Value"
+    >
+      50
+    </span>
+    <h4
+      class="Label"
+    >
+      Stat
+    </h4>
+  </div>
+</div>
+`;
+
+exports[`stat snapshot tests 2`] = `
+<div>
+  <button
+    class="Stat Clickable"
+  >
+    <span
+      class="Value"
+    >
+      50
+    </span>
+    <h4
+      class="Label"
+    >
+      Stat
+    </h4>
+  </button>
+</div>
+`;
+
+exports[`stat snapshot tests 3`] = `
+<div>
+  <div
+    class="Stat Fluid"
+    disabled=""
+    focusable="false"
+  >
+    <span
+      class="Value"
+    >
+      50
+    </span>
+    <h4
+      class="Label"
+    >
+      Stat
+    </h4>
+  </div>
+</div>
+`;
+
+exports[`stat snapshot tests 4`] = `
+<div>
+  <div
+    class="Stat"
+    disabled=""
+    focusable="false"
+  >
+    <span
+      class="Value"
+    >
+      50
+    </span>
+    <h4
+      class="Label"
+    >
+      Stat
+    </h4>
+    <span
+      class="Sub"
+    >
+      Component
+    </span>
+  </div>
+</div>
+`;

--- a/packages/cascara/src/ui/Stat/__globals.js
+++ b/packages/cascara/src/ui/Stat/__globals.js
@@ -1,0 +1,16 @@
+import pt from 'prop-types';
+
+export const PROP_TYPES = {
+  /** Stats can have their own css class name */
+  className: pt.string,
+  /** Stats can be fuild */
+  fluid: pt.bool,
+  /** Stats can have a label */
+  label: pt.string,
+  /** Stats can be clickable */
+  onClick: pt.func,
+  /** Stats can have a sub text */
+  sub: pt.oneOfType([pt.number, pt.string]),
+  /** Stats can have a value */
+  value: pt.oneOfType([pt.number, pt.string]),
+};

--- a/packages/cascara/src/ui/Stat/index.js
+++ b/packages/cascara/src/ui/Stat/index.js
@@ -1,0 +1,1 @@
+export { default } from './Stat';


### PR DESCRIPTION
## Resolves [FDS-382](https://espressive.atlassian.net/browse/FDS-382).

This creates the initial iteration of a Stats component MVP.

## New Component Checklist

- [x] Includes unit tests for _ALL_ required FDS use cases
- [x] Does not mute any top level API props in React
- [x] Includes an explanation for any changes to Jest snapshots (should be a PR tag automatically added if this happens)
- [x] Component uses `React.forwardRef()` when a single DOM node is returned, _AND_ it makes React-sense to access that DOM node
