### PR TITLE
chore(FDS-427): [Cascara] - add @espressive/prop-types as peer-dep

### DIFF
--- a/.changeset/great-chefs-judge.md
+++ b/.changeset/great-chefs-judge.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+chore(FDS-427): [Cascara] - add @espressive/prop-types as peer-dep

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@4.7.0
-  slack: circleci/slack@4.4.4
+  node: circleci/node@5.0.0
+  slack: circleci/slack@4.5.1
 
 parameters:
   installed-key:
     type: string
-    default: cascara-MONOREPO_INSTALLED-{{ .Revision }}-14
+    default: cascara-MONOREPO_INSTALLED-{{ .Revision }}
 
 aliases:
   - &is_main
@@ -43,7 +43,9 @@ jobs:
     <<: *job_executor
     steps:
       - checkout
-      - node/install-packages:
+      - node/install-packages: # https://circleci.com/developer/orbs/orb/circleci/node#commands-install-packages
+          cache-only-lockfile: true
+          check-cache: always # yarn berry zero installs
           override-ci-command: yarn install --immutable
           pkg-manager: yarn
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   installed-key:
     type: string
-    default: cascara-MONOREPO_INSTALLED-{{ .Revision }}
+    default: cascara-MONOREPO_INSTALLED-{{ .Revision }}-14
 
 aliases:
   - &is_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       - node/install-packages: # https://circleci.com/developer/orbs/orb/circleci/node#commands-install-packages
           cache-only-lockfile: true
           check-cache: always # yarn berry zero installs
+          cache-version: v2
           override-ci-command: yarn install --immutable
           pkg-manager: yarn
       - run:

--- a/packages/cascara/package.json
+++ b/packages/cascara/package.json
@@ -65,6 +65,7 @@
   },
   "peerDependencies": {
     "@espressive/design-tokens": "*",
+    "@espressive/prop-types": "*",
     "@fluentui/react-northstar": ">=0.57.0",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",

--- a/packages/cascara/package.json
+++ b/packages/cascara/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@espressive/cascara",
   "version": "1.0.0",
-  "description": "Espressive's Cascara FDS",
+  "description": "Espressive's Functional Design System",
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:Espressive/cascara.git",

--- a/packages/cascara/package.json
+++ b/packages/cascara/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@espressive/cascara",
   "version": "1.0.0",
+  "description": "Espressive's Cascara FDS",
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:Espressive/cascara.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2673,6 +2673,7 @@ __metadata:
     semantic-ui-react: 2.0.3
   peerDependencies:
     "@espressive/design-tokens": "*"
+    "@espressive/prop-types": "*"
     "@fluentui/react-northstar": ">=0.57.0"
     "@types/react": ^16.8.0
     "@types/react-dom": ^16.8.0


### PR DESCRIPTION
Closes [FDS-427](https://espressive.atlassian.net/browse/FDS-427).


### Dependencies
add `@espressive/prop-types` as peer-dep

## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
