### PR TITLE
chore(FDS-444): [Danger.js] - Do not check and fail for dependencies and fixtures in release PRs

### DIFF
--- a/.danger/index.ts
+++ b/.danger/index.ts
@@ -38,6 +38,10 @@ const isTargetBranchDevelopOrMain = ['main', 'develop'].includes(targetBranch);
 const isTargetBranchMain = targetBranch === 'main';
 const isCurrentDevelop = currentBranch === 'develop';
 
+// [FDS-444]: identify release branches and PRs
+const isCurrentAReleaseBranch = currentBranch.search(/^release/) !== -1;
+const isReleasePR = isCurrentAReleaseBranch && isTargetBranchMain;
+
 const shouldDangerCheckPR =
   isCurrentDevelopOrMain !== isTargetBranchDevelopOrMain;
 
@@ -84,7 +88,8 @@ if (
   changed.packages &&
   !hasDescriptionSection('dependencies') &&
   !isSnyk &&
-  shouldDangerCheckPR
+  shouldDangerCheckPR &&
+  !isReleasePR
 ) {
   for (let file of changed.packages) {
     fail(
@@ -97,7 +102,8 @@ if (
 if (
   changed.snapshots &&
   !hasDescriptionSection('snapshots') &&
-  shouldDangerCheckPR
+  shouldDangerCheckPR &&
+  !isReleasePR
 ) {
   for (let file of changed.snapshots) {
     fail(


### PR DESCRIPTION
Resolves FDS-444.

This changes Danger.js' configuration to identify release -> main PRs and bypass the check for dependencies and fixtures in Release PRs.

The following errors should not popup in the aforementioned case.

## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
