### PR TITLE
fix(FDS-515): [Dashboard] widget line does not implement stacked prop

### DIFF
--- a/.changeset/rich-nails-guess.md
+++ b/.changeset/rich-nails-guess.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+fix(FDS-515): [Dashboard] widget line does not implement stacked prop

--- a/packages/cascara/src/components/Dashboard/Dashboard.fixture.js
+++ b/packages/cascara/src/components/Dashboard/Dashboard.fixture.js
@@ -5,7 +5,6 @@ import pieData2 from './tests/data/Pie2';
 import pieDataChannel from './tests/data/PieChannel';
 import geoMapData from './tests/data/GeoMap';
 import barData from './tests/data/Bar';
-import barData2 from './tests/data/Bar2';
 import barDataDevice from './tests/data/BarDevice';
 import heatMapData from './tests/data/HeatMap';
 

--- a/packages/cascara/src/components/Dashboard/Dashboard.fixture.js
+++ b/packages/cascara/src/components/Dashboard/Dashboard.fixture.js
@@ -113,11 +113,39 @@ const dashboardConfig = [
   {
     axisBottomLabel: 'Month',
     axisLeftLabel: 'Count',
-    data: barData2,
+    data: [
+      {
+        data: [
+          {
+            x: '12/14',
+            y: 43,
+          },
+        ],
+        id: 'Deflected',
+      },
+      {
+        data: [
+          {
+            x: '12/14',
+            y: 19,
+          },
+        ],
+        id: 'Not Deflected',
+      },
+      {
+        data: [
+          {
+            x: '12/14',
+            y: 3,
+          },
+        ],
+        id: 'Empty',
+      },
+    ],
     indexBy: 'month',
     keys: ['Deflected', 'Not Deflected'],
     title: 'Deflected VS Not Deflected',
-    widget: 'bar',
+    widget: 'line',
   },
   {
     data: pieDataChannel,

--- a/packages/cascara/src/components/Dashboard/widgets/WidgetLine.js
+++ b/packages/cascara/src/components/Dashboard/widgets/WidgetLine.js
@@ -18,7 +18,13 @@ const propTypes = {
 /**
  * Widget for @nivo/line.
  */
-const WidgetLine = ({ axisBottomLabel, axisLeftLabel, data, ...rest }) => {
+const WidgetLine = ({
+  axisBottomLabel,
+  axisLeftLabel,
+  data,
+  stacked,
+  ...rest
+}) => {
   const CHART_CONFIG = {
     axisBottom: {
       ...AXIS_CONFIG,
@@ -42,7 +48,7 @@ const WidgetLine = ({ axisBottomLabel, axisLeftLabel, data, ...rest }) => {
     useMesh: true,
     xScale: { type: 'point' },
     yScale: {
-      stacked: true,
+      stacked,
       type: 'linear',
     },
   };


### PR DESCRIPTION

### Fixtures
Fixture of Dashboard changed to reflect WidgetLine's stacked prop implementation

## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
