### PR TITLE
chore(FDS-389):[Docs]: Fix propTypes for Table

### DIFF
--- a/.changeset/brave-grapes-move.md
+++ b/.changeset/brave-grapes-move.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+chore(FDS-389):[Docs]: Fix propTypes for Table

--- a/packages/cascara/src/components/Table/Table.js
+++ b/packages/cascara/src/components/Table/Table.js
@@ -6,7 +6,11 @@ import TableBase from './TableBase';
 import TableLoading from '../../private/TemporaryLoading';
 import TableEmpty from '../../private/TemporaryEmpty';
 
-import { TABLE_SHAPE } from './__propTypes';
+import pt from 'prop-types';
+import { actionModules, dataModules } from '../../modules/ModuleKeys';
+
+const actionModuleOptions = Object.keys(actionModules);
+const dataModuleOptions = Object.keys(dataModules);
 
 /** This is a Table */
 const Table = (props) => {
@@ -37,6 +41,76 @@ const Table = (props) => {
   );
 };
 
-Table.propTypes = TABLE_SHAPE;
+Table.propTypes = {
+  /** Actions will be appended to each row, they'll appear as buttons. */
+  actions: pt.shape({
+    actionButtonMenuIndex: pt.number,
+
+    modules: pt.arrayOf(
+      pt.shape({
+        module: pt.oneOf(actionModuleOptions).isRequired,
+      })
+    ),
+
+    // Resolve record actions.
+    // A function that returns the actions available to the current row
+    resolveRecordActions: pt.func,
+  }),
+
+  // An array of objects.
+  //
+  // Every object in this array will potencially be rendered as a table row.
+  data: pt.arrayOf(pt.shape({})),
+
+  // DEPRECATED: The main configuration for your table. Here you can specify the columns to display
+  // as well as the available actions (if any) for each row.
+  dataConfig: pt.shape({
+    /** DEPRECATED - use actions instead */
+    actionButtonMenuIndex: pt.number,
+
+    /** DEPRECATED - use actions instead */
+    actions: pt.arrayOf(
+      pt.shape({
+        module: pt.oneOf(actionModuleOptions).isRequired,
+      })
+    ),
+
+    /** DEPRECATED dataDisplay instead */
+    display: pt.arrayOf(
+      pt.shape({
+        module: pt.oneOf(dataModuleOptions).isRequired,
+      })
+    ),
+  }),
+
+  /** Here you can describe each of the visible columns in your table. */
+  dataDisplay: pt.arrayOf(
+    pt.shape({
+      module: pt.oneOf(dataModuleOptions).isRequired,
+    })
+  ),
+
+  // Event handler.
+  //
+  // An event handler you can pass to handle every event your table emits.
+  onAction: pt.func,
+
+  // Resolve record actions.
+  // A function that returns the actions available to the current row
+  resolveRecordActions: pt.func,
+
+  // Selection
+  selections: pt.oneOfType([
+    pt.bool,
+    pt.exact({
+      max: pt.number,
+    }),
+  ]),
+
+  // Unique ID Attribute.
+  //
+  // specifies the attribute that uniquely identifies every object in the 'data' array.
+  uniqueIdAttribute: pt.string,
+};
 
 export default Table;


### PR DESCRIPTION
Currently, docgen does not have support importing propTypes from external locations. 
https://github.com/reactjs/react-docgen/issues/33

There is an external package named https://www.npmjs.com/package/react-docgen-external-proptypes-handler but does not have the full support, the proptype description appears as a custom without a clear reference:
<img width="405" alt="Screen Shot 2022-02-16 at 4 05 05 PM" src="https://user-images.githubusercontent.com/87443054/154368392-9a56b64d-905e-4907-95b7-efd346b3b618.png">

Since this feature is not ready to be used, the propTypes for the table component has been moved to the owner component:
<img width="919" alt="image" src="https://user-images.githubusercontent.com/87443054/154369067-ade0a98a-e690-4e4e-ae53-b051fb208539.png">


## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
