### PR TITLE
chore(FDS-484): [Monorepo] - update faker

### DIFF
--- a/.changeset/real-trees-heal.md
+++ b/.changeset/real-trees-heal.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+chore(FDS-484): [Monorepo] - update faker

--- a/ADR/faker.md
+++ b/ADR/faker.md
@@ -1,0 +1,4 @@
+# Faker
+
+Faker has been moved from a [personal github account](https://github.com/Marak/Faker.js#readme) to an [organization](https://github.com/faker-js), this change broke the history of the repository. There is no v6.6.6 as vscode suggests, [v6 is still in alpha](https://github.com/faker-js/faker/releases/tag/v6.0.0-alpha.7).
+Faker is only used in Fixtures and tests, it is not a critical part of Cascara so we are sticking to our current versions. No updated dependencies.


### PR DESCRIPTION
## Update faker 

Faker has been moved from a [personal github account](https://github.com/Marak/Faker.js#readme) to an [organization](https://github.com/faker-js), this change broke the history of the repository. There is no v6.6.6 as vscode suggests, [v6 is still in alpha](https://github.com/faker-js/faker/releases/tag/v6.0.0-alpha.7).
Faker is only used in Fixtures and tests, it is not a critical part of Cascara so we are sticking to our current versions. No updated dependencies.

## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
