### PR TITLE
chore(FDS-477): [Monorepo] create ADR for dotenv update

### DIFF
--- a/ADR/dotenv.md
+++ b/ADR/dotenv.md
@@ -1,0 +1,11 @@
+# Dotenv
+
+Version: 8.2.0
+Date: 20191015
+
+The repository of dotenv doesn't maintain a changelog nor they have any releases, only tags. They seem not to be following the `semver` standard. This makes it difficult to follow up and see it there are any breaking changes.
+In later versions, `dotenv` won't support prefix invocation, such as the one we use for `Framer`. There is a `dotenv-cli` tool for that, but we would be adding more dependencies. Since `dotenv` is only used for non-critical tasks like `Framer`, is in our interest to keep the current version as it still does what we want.
+
+### Ecosystem updates
+
+- none


### PR DESCRIPTION
This adds an ADR file to explain why we are staying in v8.2.0.

## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
