### PR TITLE
bugfix(FDS-519): [Atoms] Fix typo in prop-types

### DIFF
--- a/.changeset/chilly-peas-tap.md
+++ b/.changeset/chilly-peas-tap.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+bugfix(FDS-519): [Atoms] Fix typo in prop-types

--- a/packages/cascara/src/atoms/DatePicker/DatePicker.js
+++ b/packages/cascara/src/atoms/DatePicker/DatePicker.js
@@ -2,13 +2,15 @@ import React, { useCallback } from 'react';
 import 'antd/dist/antd.css';
 import { DatePicker as AntDatePicker } from 'antd';
 import pt from '@espressive/prop-types';
+import PICKER_TYPE from './_globals';
 
 const propTypes = {
   /** Function that will hold the result-date selected */
-  onChange: pt.function,
+  onChange: pt.func,
   /** String that will define the type of calendar to present date|week|month|quarter|year */
-  picker: pt.string,
+  picker: pt.oneOf([...Object.keys(PICKER_TYPE), null]),
 };
+
 const DatePicker = ({ onChange, ...rest }) => {
   const handleOnChange = useCallback(
     (date, dateString) => {

--- a/packages/cascara/src/atoms/DatePicker/_globals.js
+++ b/packages/cascara/src/atoms/DatePicker/_globals.js
@@ -1,0 +1,8 @@
+const PICKER_TYPE = {
+  month: 'month',
+  quarter: 'quarter',
+  week: 'week',
+  year: 'year',
+};
+
+export default PICKER_TYPE;

--- a/packages/cascara/src/atoms/TimePicker/TimePicker.js
+++ b/packages/cascara/src/atoms/TimePicker/TimePicker.js
@@ -7,7 +7,7 @@ const propTypes = {
   /**  format time 'HH:mm or HH:mm:ss'*/
   format: pt.string,
   /** Function that will hold the result-time selected */
-  onChange: pt.function,
+  onChange: pt.func,
   /** optional: error|status */
   status: pt.string,
 };


### PR DESCRIPTION
Fix typo in prop-types

## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
