### PR TITLE
chore(DEV-19412): [TimePicker] Add html native input time

### DIFF
--- a/.changeset/light-crews-wink.md
+++ b/.changeset/light-crews-wink.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+chore(DEV-19412): [TimePicker] Close modal until a time is selected

--- a/.changeset/tricky-ravens-greet.md
+++ b/.changeset/tricky-ravens-greet.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+chore(DEV-19412): [TimePicker] Add html native input time

--- a/packages/cascara/src/atoms/TimePicker/TimePicker.fixture.js
+++ b/packages/cascara/src/atoms/TimePicker/TimePicker.fixture.js
@@ -8,8 +8,10 @@ export default {
   defaultTimeSec: (
     <TimePicker
       defaultValue={moment('15:08', format)}
+      format='h:mm a'
       onChange={handleChange}
       picker='quarter'
+      useNativeInput
     />
   ),
   time: <TimePicker format={format} onChange={handleChange} />,

--- a/packages/cascara/src/atoms/TimePicker/TimePicker.js
+++ b/packages/cascara/src/atoms/TimePicker/TimePicker.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { TimePicker as AntdTimePicker } from 'antd';
 import pt from '@espressive/prop-types';
 import locales from '../../shared/locales';
@@ -15,12 +15,18 @@ const propTypes = {
 };
 
 const TimePicker = ({ format, lang, onChange, ...rest }) => {
+  const [isOpen, setOpen] = useState(false);
   const handleOnChange = useCallback(
     (time, timeString) => {
+      setOpen(false);
       onChange(time, timeString);
     },
     [onChange]
   );
+
+  const handleOnClick = useCallback((val) => {
+    setOpen(val);
+  }, []);
 
   return (
     <AntdTimePicker
@@ -28,6 +34,8 @@ const TimePicker = ({ format, lang, onChange, ...rest }) => {
       format={format}
       locale={lang ? locales[lang] : ''}
       onChange={handleOnChange}
+      onOpenChange={handleOnClick}
+      open={isOpen}
     />
   );
 };

--- a/packages/cascara/src/atoms/TimePicker/TimePicker.js
+++ b/packages/cascara/src/atoms/TimePicker/TimePicker.js
@@ -18,7 +18,6 @@ const TimePicker = ({ format, lang, onChange, ...rest }) => {
   const [isOpen, setOpen] = useState(false);
   const handleOnChange = useCallback(
     (time, timeString) => {
-      setOpen(false);
       onChange(time, timeString);
     },
     [onChange]

--- a/packages/cascara/src/atoms/TimePicker/TimePicker.js
+++ b/packages/cascara/src/atoms/TimePicker/TimePicker.js
@@ -1,7 +1,10 @@
 import React, { useCallback, useState } from 'react';
+import moment from 'moment';
 import { TimePicker as AntdTimePicker } from 'antd';
 import pt from '@espressive/prop-types';
 import locales from '../../shared/locales';
+import { Button, Input } from 'reakit';
+import styles from '../../modules/DataModule.module.scss';
 
 const propTypes = {
   /**  format time 'HH:mm or HH:mm:ss'*/
@@ -12,10 +15,26 @@ const propTypes = {
   onChange: pt.func,
   /** optional: error|status */
   status: pt.string,
+
+  useNativeInput: pt.bool,
 };
 
-const TimePicker = ({ format, lang, onChange, ...rest }) => {
-  const [isOpen, setOpen] = useState(false);
+const TimePicker = ({ format, lang, onChange, useNativeInput, ...rest }) => {
+  const [inputValue, setValue] = useState('');
+
+  const handleNativeChange = useCallback(
+    ({ target }) => {
+      const { value } = target;
+      setValue(value);
+    },
+    [setValue]
+  );
+
+  const handleOkButton = useCallback(() => {
+    const time = moment(inputValue, format);
+    onChange(time, inputValue);
+  }, [inputValue, format, onChange]);
+
   const handleOnChange = useCallback(
     (time, timeString) => {
       onChange(time, timeString);
@@ -23,18 +42,30 @@ const TimePicker = ({ format, lang, onChange, ...rest }) => {
     [onChange]
   );
 
-  const handleOnClick = useCallback((val) => {
-    setOpen(val);
-  }, []);
-
-  return (
+  return useNativeInput ? (
+    <>
+      <Input
+        {...rest}
+        className={styles.Input}
+        onChange={handleNativeChange}
+        type='time'
+        value={inputValue}
+      />
+      <Button
+        className={`ui basic icon button`}
+        disabled={!inputValue}
+        onClick={handleOkButton}
+        style={{ padding: '0.4em' }}
+      >
+        Ok
+      </Button>
+    </>
+  ) : (
     <AntdTimePicker
       {...rest}
       format={format}
       locale={lang ? locales[lang] : ''}
       onChange={handleOnChange}
-      onOpenChange={handleOnClick}
-      open={isOpen}
     />
   );
 };


### PR DESCRIPTION
Add HTML native input time
If the component receives the prop **useNativeInput**, a native time input will be rendered.
If the component DOES NOT receive the prop **useNativeInput**, an andt time component will be rendered.

## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [ ] I have completed all of the above and have enabled `auto-merge` for this PR
