### PR TITLE
fix(FDS-529) Update WidgetList logic to take into account rowaction column

### DIFF
--- a/.changeset/wicked-ladybugs-kneel.md
+++ b/.changeset/wicked-ladybugs-kneel.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+fix(FDS-529) Update WidgetList logic to take into account rowaction column

--- a/packages/cascara/src/components/Dashboard/DashboardDX.fixture.js
+++ b/packages/cascara/src/components/Dashboard/DashboardDX.fixture.js
@@ -66,7 +66,27 @@ const WIDGETS = [
     data: undefined,
     // keys: ['country', 'fries', 'curry'],
     // rowAction: (obj) => console.log(obj), // Without a rowAction defined, no row action will show. Note that the function gets the original object passed to it.
-    title: 'List',
+    title: 'List (simple)',
+    widget: 'list',
+  },
+  {
+    data: undefined,
+    keys: ['not helpful', 'no data', 'helpful', 'month'],
+    rowAction: (obj) => console.log(obj), // Without a rowAction defined, no row action will show. Note that the function gets the original object passed to it.
+    footer: {
+      data: {
+        'not helpful': {
+          value: 1,
+        },
+        'no data': {
+          value: 1,
+        },
+        helpful: {
+          value: 1,
+        },
+      },
+    },
+    title: 'List with Actions and footer',
     widget: 'list',
   },
   {

--- a/packages/cascara/src/components/Dashboard/widgets/WidgetList.js
+++ b/packages/cascara/src/components/Dashboard/widgets/WidgetList.js
@@ -3,6 +3,7 @@ import pt from 'prop-types';
 import Widget, { propTypes as widgetPT } from './Widget';
 import WidgetListAction from './WidgetListAction';
 import { getDataState } from './dataState';
+import { isEmpty, isUndefined } from 'lodash';
 import styles from './WidgetList.module.scss';
 
 const propTypes = {
@@ -39,25 +40,33 @@ const getPreparedData = (keys, data) =>
       )
     : data;
 
-const buildFooter = ({ keys, footerData }) => {
-  if (footerData !== undefined) {
-    return keys.map((key, i) => {
-      if (footerData[key]?.value) {
-        return <th key={i}>{footerData[key].value}</th>;
+const buildFooter = ({ action, keys, footerData }) => {
+  if (!isUndefined(footerData) && !isEmpty(footerData)) {
+    const columns = keys.map((key, i) => {
+      if (
+        Object.keys(footerData).includes(key) &&
+        !isUndefined(footerData[key]?.value)
+      ) {
+        return <th key={i}>{footerData[key]?.value}</th>;
+      } else {
+        return <th key={i} />;
       }
-      return <th key={i} />;
     });
+    if (!isUndefined(action)) {
+      columns.push(<th />);
+    }
+    return columns;
   } else {
     return null;
   }
 };
-const renderFooter = ({ footer, keys }) => {
+const renderFooter = ({ action, footer, keys }) => {
   const { data, settings } = footer;
   const { footerHidden, tableFooterSticky } = styles;
   const classNames = settings?.hidden ? footerHidden : tableFooterSticky;
-  return footer && data ? (
+  return footer && !isEmpty(data) ? (
     <tfoot className={`${classNames} animated-sticky-footer`}>
-      {buildFooter({ footerData: data, keys })}
+      {buildFooter({ action, footerData: data, keys })}
     </tfoot>
   ) : null;
 };
@@ -119,7 +128,12 @@ const WidgetList = ({ data, footer, header, keys, rowAction, ...rest }) => {
               </tr>
             ))}
           </tbody>
-          {footer && renderFooter({ footer, keys })}
+          {footer &&
+            renderFooter({
+              action: rowAction,
+              footer,
+              keys: Object.keys(preparedData[0]),
+            })}
         </table>
       )}
     </Widget>


### PR DESCRIPTION
The issue was when a list have a row action the footer was not creating a column for the row action so the footer looked incomplete.
⬇️ The bug
<img width="878" alt="image" src="https://user-images.githubusercontent.com/80282588/200671011-6b3b69ad-04f2-4230-a112-e15b80153435.png">

With this change, We're taking into account the rowAction and if a rowAction function is defined adding as the last column an element <th /> 
Also, we updated the fixtures to describe a simple widget list and a widgetList with a footer and rowAction
<img width="862" alt="image" src="https://user-images.githubusercontent.com/80282588/200671705-11b22c4b-804e-4e4e-b1f5-ab954100f38f.png">
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/80282588/200671754-b9a131b6-5ed9-4121-a605-d8366f687ce3.png">
<img width="863" alt="image" src="https://user-images.githubusercontent.com/80282588/200671817-ebd27798-debd-4340-af6e-39aeb09d222c.png">



## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
