### PR TITLE
FIX(FDS-528) Fix small visual issues in table when singleLined prop is applied and table has actions.

### DIFF
--- a/.changeset/sweet-actors-sing.md
+++ b/.changeset/sweet-actors-sing.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+FIX(FDS-528) Fix small visual issues in table when singleLined prop is applied and table has actions.

--- a/packages/cascara/src/components/Table/Table.module.scss
+++ b/packages/cascara/src/components/Table/Table.module.scss
@@ -140,5 +140,10 @@ $header-background: #eee;
       background-color: transparent;
       border-bottom: solid 1px #dddcde;
     }
+    .CellActions {
+      &:before {
+        background-image: none;
+      }
+    }
   }
 }

--- a/packages/cascara/src/components/Table/atoms/Checkbox/Checkbox.module.scss
+++ b/packages/cascara/src/components/Table/atoms/Checkbox/Checkbox.module.scss
@@ -1,3 +1,5 @@
 ._ {
   width: 24px;
+  height: 24px;
+  align-self: center;
 }

--- a/packages/cascara/src/components/Table/fixtures/UserExperience.fixture.js
+++ b/packages/cascara/src/components/Table/fixtures/UserExperience.fixture.js
@@ -251,6 +251,26 @@ export default {
       />
     </Provider>
   ),
+  withActionsSingleLined: (
+    <Provider>
+      <WithActions
+        actions={{
+          actionButtonMenuIndex: 0,
+          modules: [
+            {
+              content: 'View',
+              module: 'button',
+              name: 'viewInFAQ',
+            },
+          ],
+        }}
+        data={results}
+        dataDisplay={COLUMNS}
+        singleLined
+        uniqueIdAttribute='eid'
+      />
+    </Provider>
+  ),
   withoutActionBar: (props) => (
     <Provider>
       <WithoutActionBar
@@ -282,6 +302,16 @@ export default {
       <WithoutActions
         data={results}
         dataDisplay={COLUMNS}
+        uniqueIdAttribute='eid'
+      />
+    </Provider>
+  ),
+  withoutActionsSingleLined: (
+    <Provider>
+      <WithoutActions
+        data={results}
+        dataDisplay={COLUMNS}
+        singleLined
         uniqueIdAttribute='eid'
       />
     </Provider>

--- a/packages/cascara/src/components/Table/tests/TableSnapshot.test.snap
+++ b/packages/cascara/src/components/Table/tests/TableSnapshot.test.snap
@@ -114,6 +114,7 @@ exports[`Table snapshot tests actions with non-existent module 1`] = `
       aria-expanded="false"
       aria-haspopup="menu"
       class="ui basic icon button"
+      style="border: 1px solid #dddcde; box-shadow: none; height: 35px; margin: 5px; padding: 0px; width: 34px;"
       type="button"
     >
       <svg
@@ -361,6 +362,7 @@ exports[`Table snapshot tests dataDisplay with non-existent module 1`] = `
       aria-expanded="false"
       aria-haspopup="menu"
       class="ui basic icon button"
+      style="border: 1px solid #dddcde; box-shadow: none; height: 35px; margin: 5px; padding: 0px; width: 34px;"
       type="button"
     >
       <svg
@@ -529,6 +531,7 @@ exports[`Table snapshot tests with actions 1`] = `
       aria-expanded="false"
       aria-haspopup="menu"
       class="ui basic icon button"
+      style="border: 1px solid #dddcde; box-shadow: none; height: 35px; margin: 5px; padding: 0px; width: 34px;"
       type="button"
     >
       <svg
@@ -659,6 +662,7 @@ exports[`Table snapshot tests with deprecated props 1`] = `
       aria-expanded="false"
       aria-haspopup="menu"
       class="ui basic icon button"
+      style="border: 1px solid #dddcde; box-shadow: none; height: 35px; margin: 5px; padding: 0px; width: 34px;"
       type="button"
     >
       <svg

--- a/packages/cascara/src/private/ActionsMenu/ActionsMenu.js
+++ b/packages/cascara/src/private/ActionsMenu/ActionsMenu.js
@@ -11,7 +11,17 @@ import { popperOverTrigger } from '../../lib/popperModifiers';
 
 const MemoActionsMenuItem = React.memo(ActionsMenuItem);
 const DEFAULT_TRIGGER = (
-  <Button className='ui basic icon button'>
+  <Button
+    className={`ui basic icon button`}
+    style={{
+      border: 'solid 1px #dddcde',
+      boxShadow: ' none',
+      height: '35px',
+      margin: '5px',
+      padding: '0',
+      width: '34px',
+    }}
+  >
     <InlineIcon icon={verticalmenuIcon} />
   </Button>
 );


### PR DESCRIPTION
Remove gradient image before CellActions on singleLined tables and update UserExperience/Table fixtures to describe: a single lined table with and without actions. 

You can check the changes in this version by adding a singleLined Prop in the table sandboxes  on this vercel instance https://cascara-m83ofy48r-espressive1.vercel.app/

This was the bug : 
![Image 2022-11-08 at 5 54 36 p m](https://user-images.githubusercontent.com/80282588/200701671-48b0be04-b110-47cd-bab1-88e682f9174e.jpg)

This is how it looks after the work in this PR: 

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/80282588/200701775-6d341019-3530-4116-b75a-f813ac78a342.png">

Closer to the design proposed by UX team here 
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/80282588/200701938-ac2ba77a-8cd9-4610-811a-6addc4d1688e.png">
https://projects.invisionapp.com/d/main/#/console/22129485/469744693/preview

**NO BREAKING CHANGES TO THE OTHER TYPES OF TABLES **

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/80282588/200702249-8dc64e29-53f7-429c-b994-a20f92d9e8d4.png">
<img width="1476" alt="image" src="https://user-images.githubusercontent.com/80282588/200702284-198578fa-533b-4614-b65d-6db3b640c22f.png">
<img width="1495" alt="image" src="https://user-images.githubusercontent.com/80282588/200702306-7a0929cc-c9a2-419a-b12c-492d076a8a90.png">




## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
