### PR TITLE
chore/DEV-21286 Set a minWidth for every dashboard widget

### DIFF
--- a/.changeset/four-trees-protect.md
+++ b/.changeset/four-trees-protect.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+chore/DEV-21286 Set a minWidth for every dashboard widget

--- a/packages/cascara/src/components/Dashboard/widgets/Widget.js
+++ b/packages/cascara/src/components/Dashboard/widgets/Widget.js
@@ -29,6 +29,8 @@ const propTypes = {
   isLoading: pt.bool,
   /** A widget can contain scrolling content */
   isScrolling: pt.bool,
+  /** The width of a widget */
+  minWidth: pt.oneOfType([pt.number, pt.oneOf(['auto'])]),
   onScroll: pt.func,
   /** A widget can display with a title */
   title: pt.string,
@@ -46,6 +48,7 @@ const Widget = ({
   isEmpty = false,
   isLoading = false,
   isScrolling = false,
+  minWidth = '100%',
   title,
   onScroll,
   ...rest
@@ -100,7 +103,7 @@ const Widget = ({
             className
           )}
           onScroll={isScrolling && onScroll ? onScroll : void 0}
-          style={{ height: height }}
+          style={{ height: height, minWidth: minWidth }}
         >
           {isLoading ? (
             <div className='ui active centered inline loader' />


### PR DESCRIPTION
Set a minWidth for every dashboard widget

There shouldn't exist any visible changes:
<img width="1357" alt="image" src="https://user-images.githubusercontent.com/87443054/211649818-a0eff9ce-fed2-4d90-ac43-c3671fd75732.png">

## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [ ] I have completed all of the above and have enabled `auto-merge` for this PR
