### PR TITLE
feat(DEV-21966) Truncate columns in Table by prop definition

### DIFF
--- a/.changeset/hot-news-smoke.md
+++ b/.changeset/hot-news-smoke.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+feat(DEV-21966) Truncate columns in Table by prop definition

--- a/packages/cascara/src/components/Table/TableBase.js
+++ b/packages/cascara/src/components/Table/TableBase.js
@@ -64,6 +64,7 @@ const TableBase = ({
   singleLined,
   sortable,
   sortState,
+  truncateColumns,
   uniqueIdAttribute,
   ...rest
 }) => {
@@ -280,6 +281,7 @@ const TableBase = ({
         selection,
         sortState,
         sortableColumns,
+        truncateColumns,
         uniqueIdAttribute: uniqueid,
       }}
       {...rest}

--- a/packages/cascara/src/components/Table/TableBody.js
+++ b/packages/cascara/src/components/Table/TableBody.js
@@ -6,7 +6,8 @@ import { ModuleContext } from '../../modules/context';
 import TableRow from './TableRow';
 
 const TableBody = () => {
-  const { data, dataDisplay, uniqueIdAttribute } = useContext(ModuleContext);
+  const { data, dataDisplay, truncateColumns, uniqueIdAttribute } =
+    useContext(ModuleContext);
 
   const rows = useMemo(
     () =>
@@ -25,8 +26,14 @@ const TableBody = () => {
       <tbody className={styles.BodyContainer}>
         {rows?.map((record) => {
           const { data, ...rest } = record;
-
-          return <TableRow config={rest} key={record.id} record={data} />;
+          return (
+            <TableRow
+              config={rest}
+              key={record.id}
+              record={data}
+              truncateColumns={truncateColumns}
+            />
+          );
         })}
       </tbody>
     </Boundaries>

--- a/packages/cascara/src/components/Table/TableRow.js
+++ b/packages/cascara/src/components/Table/TableRow.js
@@ -31,9 +31,10 @@ const propTypes = {
     id: pt.oneOfType([pt.string, pt.number]),
   }),
   record: pt.shape({}),
+  truncateColumns: pt.number,
 };
 
-const TableRow = ({ config = {}, record = {} }) => {
+const TableRow = ({ config = {}, record = {}, truncateColumns }) => {
   const { id, columns } = config;
   const {
     resolveRecordActions,
@@ -89,7 +90,14 @@ const TableRow = ({ config = {}, record = {} }) => {
   const rowCells = columns.map((column) => {
     const { module, isLabeled, ...rest } = column;
     const Module = dataModules[module];
-    const moduleValue = record[column.attribute];
+    let moduleValue = record[column.attribute];
+
+    if (truncateColumns > 0 && typeof moduleValue === 'string') {
+      moduleValue =
+        moduleValue.length > truncateColumns
+          ? `${moduleValue.slice(0, truncateColumns - 1)}...`
+          : moduleValue;
+    }
 
     return (
       <td className={styles.Cell} key={column.attribute}>

--- a/packages/cascara/src/components/Table/fixtures/DeveloperExperience.fixture.js
+++ b/packages/cascara/src/components/Table/fixtures/DeveloperExperience.fixture.js
@@ -119,6 +119,7 @@ export default {
     <DataWithDisplay
       data={results}
       dataDisplay={COLUMNS}
+      truncateColumns={30}
       uniqueIdAttribute='eid'
     />
   ),


### PR DESCRIPTION
Truncate columns in Table by prop definition
If the table receives the props truncateColumns, all columns that contain string information, will be truncated to the number defined in this prop:
![image](https://user-images.githubusercontent.com/87443054/228439446-f576426b-b5db-4f37-8568-11601f56b999.png)


## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
