### PR TITLE
chore(DEV-22398) Return the format selected in the datepicker

### DIFF
--- a/.changeset/silver-rice-check.md
+++ b/.changeset/silver-rice-check.md
@@ -1,0 +1,5 @@
+---
+"@espressive/cascara": patch
+---
+
+chore(DEV-22398) Return the format selected in the datepicker

--- a/packages/cascara/src/atoms/DatePicker/DatePicker.fixture.js
+++ b/packages/cascara/src/atoms/DatePicker/DatePicker.fixture.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import DatePicker from '.';
 
-const handleChange = (param, param2) => console.log(param, param2);
+const handleChange = (param, param2, param3) =>
+  console.log(param, param2, param3);
 
 export default {
   selectDate: <DatePicker onChange={handleChange} />,

--- a/packages/cascara/src/atoms/DatePicker/DatePicker.js
+++ b/packages/cascara/src/atoms/DatePicker/DatePicker.js
@@ -3,7 +3,6 @@ import { DatePicker as AntDatePicker } from 'antd';
 import pt from '@espressive/prop-types';
 import PICKER_TYPE from './_globals';
 import locales from '../../shared/locales';
-
 const propTypes = {
   /** date format */
   format: pt.string,
@@ -14,29 +13,27 @@ const propTypes = {
   /** String that will define the type of calendar to present date|week|month|quarter|year */
   picker: pt.oneOf([...Object.keys(PICKER_TYPE), null]),
 };
-
 const DatePicker = ({ format, onChange, lang, ...rest }) => {
+  const defaultLang = 'en-US';
+  const defaultFormat = 'YYYY-MM-DD';
+  const dateFormat = lang ? locales[lang]?.lang?.dateFormat : defaultFormat;
+  const locale = lang ? locales[lang] : locales[defaultLang];
+
   const handleOnChange = useCallback(
     (date, dateString) => {
-      onChange(date, dateString);
+      onChange(date, dateString, dateFormat);
     },
-    [onChange]
+    [dateFormat, onChange]
   );
-
-  const formatForLocales = locales[lang]?.lang?.dateFormat;
-  const validatedFormats =
-    formatForLocales === 'M/D/YYYY' ? 'MM/DD/YYYY' : formatForLocales;
-
   return (
     <AntDatePicker
       {...rest}
       aria-label='Date'
-      format={format || validatedFormats}
-      locale={lang ? locales[lang] : ''}
+      format={format ? format : dateFormat}
+      locale={locale}
       onChange={handleOnChange}
     />
   );
 };
-
 DatePicker.propTypes = propTypes;
 export default DatePicker;

--- a/packages/cascara/src/shared/locales/index.js
+++ b/packages/cascara/src/shared/locales/index.js
@@ -14,6 +14,7 @@ const locales = {
   de: de,
   'en-US': en_us,
   es: es,
+  'es-MX': es,
   fr: fr,
   it: it,
   ja: ja,


### PR DESCRIPTION
Return the format selected in the date picker. 
The format based on the language is defined in this component. This information will be used in app-web to later on.

## PR Author Checklist

- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] I have finished reviewing the contents of this PR for accuracy
- [x] If needed, I have included a [Changeset](https://github.com/changesets/changesets) and it follows [Semantic Versioning principles](https://semver.org/)
- [x] I have completed all of the above and have enabled `auto-merge` for this PR
